### PR TITLE
OC-4235: Implement delay loading to reduce load-time

### DIFF
--- a/lib/chef/knife/google_base.rb
+++ b/lib/chef/knife/google_base.rb
@@ -95,6 +95,16 @@ class Chef
           exit 1
         end
       end
+
+      def self.included(includer)
+        includer.class_eval do
+          deps do
+            require 'chef/json_compat'
+            require 'chef/knife'
+            Chef::Knife.load_deps
+          end
+        end
+      end
     end
   end
 end

--- a/lib/chef/knife/google_server_create.rb
+++ b/lib/chef/knife/google_server_create.rb
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'chef/knife/google_base'
 
 class Chef
   class Knife
@@ -21,15 +22,11 @@ class Chef
 
       deps do
         require 'readline'
-        require 'chef/json_compat'
         require 'chef/knife/bootstrap'
         require 'highline'
         require 'net/ssh/multi'
         require 'net/scp'
         require 'tempfile'
-        require 'chef/knife'
-        require 'chef/knife/google_base'
-
         Chef::Knife::Bootstrap.load_deps
       end
 

--- a/lib/chef/knife/google_server_delete.rb
+++ b/lib/chef/knife/google_server_delete.rb
@@ -23,12 +23,6 @@ class Chef
     class GoogleServerDelete < Knife
 
       include Knife::GoogleBase
-      deps do
-        require 'chef/knife'
-        require '/chef/json_compat'
-        Chef::Knife.load_deps
-      end
-
 
       banner "knife google server delete SERVER (options)"
 

--- a/lib/chef/knife/google_server_list.rb
+++ b/lib/chef/knife/google_server_list.rb
@@ -22,8 +22,6 @@ class Chef
         require 'stringio'
         require 'yajl'
         require 'highline'
-        require 'chef/knife'
-        require 'chef/json_compat'
         require 'tempfile'
         require 'chef/knife/google_base'
         Chef::Knife.load_deps


### PR DESCRIPTION
Here are findings,
# knife (without plugins)

```
# before delay-loading changes(Time)
    real    0m0.759s
    user    0m0.612s
    sys     0m0.072s
```
# knife(with knife-google)

```
# before delay-loading  changes(Time), 
    real    0m1.947s
    user    0m0.812s
    sys     0m0.108s

# After delay-loading  changes(Time), 
    real    0m0.781s
    user    0m0.688s
    sys     0m0.080s
```

Environment:
1. Chef Version: 10.14.2
2. Ruby Version: 1.9.3p194
3. Gem Version: 1.8.24
