### PR TITLE
supporting gcutil 1.5.0

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -76,6 +76,7 @@ Outputs a list of all servers in the currently configured Google Cloud account. 
 = LICENSE:
 
 Author:: Chirag Jog (<chiragj@websym.com>)
+Contributors:: Riccardo Carlesso (<palladiusbonton@gmail.com>)
 Copyright:: Copyright (c) 2012 Opscode, Inc.
 License:: Apache License, Version 2.0
 

--- a/lib/chef/knife/google_server_list.rb
+++ b/lib/chef/knife/google_server_list.rb
@@ -39,7 +39,7 @@ class Chef
 
       option :project_id,
         :short => "-p PROJECT_ID",
-        :long => "--project_id PROJECT_ID",
+        :long => "--project PROJECT_ID",
         :description => "The Google Compute Engine project identifier",
         :proc => Proc.new { |project| Chef::Config[:knife][:google_project] = project }
 

--- a/lib/knife-google/version.rb
+++ b/lib/knife-google/version.rb
@@ -1,3 +1,3 @@
 module KnifeGoogle
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Hi Chirag,
I'm Riccardo and work on Google Compute Engine.
I was trying to use your gem (brilliant!) and I think I found a bug:

--project_id should be deprecated in favor of --project.

In machine creation it seems to work, but in retrieving list it breaks. Look:

$ knife google server list -VV --project google.com:discoproject
WARNING: No knife configuration file found
DEBUG: Using configuration from 
DEBUG: Linux Environment
DEBUG: Executing gcutil getproject --project_id=google.com:discoproject

DEBUG: Executing gcutil listinstances --print_json --project_id=google.com:discoproject
/var/lib/gems/1.8/gems/knife-google-0.0.1/lib/chef/knife/google_server_list.rb:83:in `run': private method`select' called for nil:NilClass (NoMethodError)
    from /var/lib/gems/1.8/gems/knife-google-0.0.1/lib/chef/knife/google_server_list.rb:81:in `each'
    from /var/lib/gems/1.8/gems/knife-google-0.0.1/lib/chef/knife/google_server_list.rb:81:in`run'
    from /var/lib/gems/1.8/gems/knife-google-0.0.1/lib/chef/knife/google_server_list.rb:76:in `each'
    from /var/lib/gems/1.8/gems/knife-google-0.0.1/lib/chef/knife/google_server_list.rb:76:in`run'
    from /var/lib/gems/1.8/gems/chef-10.18.2/lib/chef/knife.rb:408:in `run_with_pretty_exceptions'
    from /var/lib/gems/1.8/gems/chef-10.18.2/lib/chef/knife.rb:168:in`run'
    from /var/lib/gems/1.8/gems/chef-10.18.2/lib/chef/application/knife.rb:123:in `run'
    from /var/lib/gems/1.8/gems/chef-10.18.2/bin/knife:25
    from /usr/local/bin/knife:19:in`load'
    from /usr/local/bin/knife:19

I hope my small change helps.
