### PR TITLE
made service accounts easier to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Some usage examples follow:
   $ knife google server create www1 -m n1-standard-1 -I debian-7-wheezy-v20131120 -Z us-central1-a -i ~/.ssh/id_rsa -x jdoe
 
   # Create a server with service account scopes
-  $ knife google server create www1 -m n1-standard-1 -I debian-7-wheezy-v20131120 -Z us-central1-a -i ~/.ssh/id_rsa -x jdoe -S https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/devstorage.full_control -s 123845678986@project.gserviceaccount.com
+  $ knife google server create www1 -m n1-standard-1 -I debian-7-wheezy-v20131120 -Z us-central1-a -i ~/.ssh/id_rsa -x jdoe --gce-service-account-scopes https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/devstorage.full_control
 
   # Delete a server (along with Chef node and API client via --purge)
   $ knife google server delete www1 --purge -Z us-central2-a
@@ -314,6 +314,11 @@ preparation instructions earlier and use the `-x` and `-i` commands
 to specify the username and the identity file for that user.  Make sure 
 to use the private key file (e.g. `~/.ssh/id_rsa`) for the identity 
 file and *not* the public key file.
+
+If you would like to set up your server with a service account, provide
+the --gce-service-account-scopes argument during server creation. The service
+account associated with your project will be used by default unless otherwise
+specified with the optional --gce-service-account-name argument.
 
 See the extended options that also allow bootstrapping the node with
 `knife google server create --help`.

--- a/lib/chef/knife/google_server_create.rb
+++ b/lib/chef/knife/google_server_create.rb
@@ -102,10 +102,11 @@ class Chef
         :description => "Service account scopes for this server",
         :default => []
 
-      option :service_account_email,
-        :long => "--gce-service-account-email EMAIL@DOMAIN",
-        :description => "Service account email for this server; required if using service-account-scopes",
-        :default => ""
+      # GCE documentation uses the term 'service account name', the api uses the term 'email'
+      option :service_account_name,
+        :long => "--gce-service-account-name NAME",
+        :description => "Service account name for this server, typically in the form of '123845678986@project.gserviceaccount.com'; default is 'default'",
+        :default => "default"
 
       option :instance_connect_ip,
         :long => "--gce-server-connect-ip INTERFACE",
@@ -456,12 +457,6 @@ class Chef
                                                    :tags => config[:tags]
                                                   )
         else
-          begin
-            raise if config[:service_account_email].length == 0
-          rescue
-            ui.error("Email address of the service account is required when using service account scopes")
-            exit 1
-          end
           zone_operation = client.instances.create(:name => @name_args.first, 
                                                    :zone=> selflink2name(zone),
                                                    :machineType => machine_type,
@@ -475,7 +470,7 @@ class Chef
                                                    :networkInterfaces => [network_interface],
                                                    :serviceAccounts => [{
                                                      'kind' => 'compute#serviceAccount',
-                                                     'email' => config[:service_account_email],
+                                                     'email' => config[:service_account_name],
                                                      'scopes' => config[:service_account_scopes]
                                                    }],
                                                    :scheduling => {

--- a/lib/knife-google/version.rb
+++ b/lib/knife-google/version.rb
@@ -14,6 +14,6 @@
 #
 module Knife
   module Google
-    VERSION = "1.3.1"
+    VERSION = "1.3.2"
   end
 end

--- a/spec/chef/knife/google_server_create_spec.rb
+++ b/spec/chef/knife/google_server_create_spec.rb
@@ -91,7 +91,7 @@ describe Chef::Knife::GoogleServerCreate do
       "-Z"+stored_zone.name, 
       stored_instance.name])
     knife_plugin.config[:service_account_scopes]=["https://www.googleapis.com/auth/userinfo.email","https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.full_control"]
-    knife_plugin.config[:service_account_email]='123845678986@project.gserviceaccount.com'
+    knife_plugin.config[:service_account_name]='123845678986@project.gserviceaccount.com'
     knife_plugin.config[:boot_disk_size]='10'
     knife_plugin.config[:metadata]=[]
     knife_plugin.config[:public_ip]='EPHEMERAL'
@@ -112,7 +112,7 @@ describe Chef::Knife::GoogleServerCreate do
       "-n"+stored_network.name,
       stored_instance.name])
     knife_plugin.config[:service_account_scopes]=["https://www.googleapis.com/auth/userinfo.email","https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.full_control"]
-    knife_plugin.config[:service_account_email]='123845678986@project.gserviceaccount.com'
+    knife_plugin.config[:service_account_name]='123845678986@project.gserviceaccount.com'
     knife_plugin.config[:boot_disk_size]='10'
     knife_plugin.config[:metadata]=[]
     knife_plugin.config[:public_ip]='EPHEMERAL'


### PR DESCRIPTION
The server create argument --gce-service-account-email is now --gce-service-account-name and optional. This will make the use of service accounts less confusing with regards to the email/name to use.

Updated readme and bumped version to 1.3.2.

I'll merge and tag after a LGTM.
