### PR TITLE
Add instance's boot disk autodelete option

### DIFF
--- a/lib/chef/knife/google_server_create.rb
+++ b/lib/chef/knife/google_server_create.rb
@@ -65,6 +65,12 @@ class Chef
         :description => "Size of the persistent boot disk between 10 and 10000 GB, specified in GB; default is '10' GB",
         :default => "10"
 
+      option :boot_disk_autodelete,
+        :long => "--[no-]gce-boot-disk-autodelete",
+        :description => "Delete boot disk when instance is being deleted.",
+        :boolean => true,
+        :default => false
+
       option :additional_disks,
         :long => "--gce-disk-additional-disks DISKS",
         :short => "-D DISKS",
@@ -428,6 +434,12 @@ class Chef
           boot_disk_name = config[:boot_disk_name]
         end
 
+        if config[:boot_disk_autodelete] then
+          boot_disk_autodelete = 'true'
+        else
+          boot_disk_autodelete = 'false'
+        end
+
         ui.info("Waiting for the boot disk insert operation to complete")
         boot_disk_insert = client.disks.insert(:sourceImage => image,
                                                :zone => selflink2name(zone),
@@ -438,7 +450,8 @@ class Chef
                   'type' => 'PERSISTENT',
                   'mode' => 'READ_WRITE',
                   'deviceName' => selflink2name(boot_disk_target_link),
-                  'source' => boot_disk_target_link
+                  'source' => boot_disk_target_link,
+                  'autoDelete' => boot_disk_autodelete
                   }]
 
         unless config[:additional_disks].to_s.empty? then

--- a/lib/chef/knife/google_server_delete.rb
+++ b/lib/chef/knife/google_server_delete.rb
@@ -81,7 +81,13 @@ class Chef
             msg_pair("Public IP Address", public_ips(instance).join(','))
             msg_pair("Private IP Address", private_ips(instance).join(','))
             puts "\n"
-            ui.warn("Persistent disks attached to this instance are not deleted with this operation")
+            autodeleted_boot = instance.disks.find { |disk| disk.auto_delete && disk.boot }
+            if autodeleted_boot
+              ui.warn("Boot disk for this instance '#{autodeleted_boot.device_name}' will be deleted together, other persistent disks attached are not deleted with this operation")
+            else
+              ui.warn("Persistent disks attached to this instance are not deleted with this operation")
+            end
+
             ui.confirm("Do you really want to delete server '#{selflink2name(zone)}:#{instance.name}'")
             client.instances.delete(:instance=>instance.name, :zone=>selflink2name(zone))
             ui.warn("Deleted server '#{selflink2name(zone)}:#{instance.name}'")

--- a/lib/google/compute/server/attached_disk.rb
+++ b/lib/google/compute/server/attached_disk.rb
@@ -22,7 +22,7 @@ module Google
     class AttachedDisk
       include Utils
 
-      attr_reader :kind, :index, :type, :mode
+      attr_reader :kind, :index, :type, :mode, :auto_delete
       attr_reader :source, :device_name, :boot
       
       def initialize(data)
@@ -33,6 +33,7 @@ module Google
         @source = data["source"]
         @device_name = data["deviceName"] 
         @boot = data["boot"]
+        @auto_delete = data["autoDelete"]
       end
     end
   end

--- a/spec/chef/knife/google_server_create_spec.rb
+++ b/spec/chef/knife/google_server_create_spec.rb
@@ -50,7 +50,8 @@ describe Chef::Knife::GoogleServerCreate do
         "type" => "PERSISTENT",
         "mode" => "READ_WRITE",
         "deviceName" => "",
-        "source" => nil}]
+        "source" => nil,
+        "autoDelete" => "false"}]
 
     if additional_disk
       # Make sure we look for the disk


### PR DESCRIPTION
It is too tiresome to delete instance and its boot disk separately.
So I made some change to accept boot disk autodelete option on instance creation. Thanks for reviewing this.