### PR TITLE
fix for undefined method 'snake_case'

### DIFF
--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -12,9 +12,10 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md", "LICENSE", "CONTRIB.md" ]
   s.summary = "Manage Google Compute Engine servers, disks, and zones"
   s.description = "Google Compute Engine Support for Chef's Knife Command"
-  s.homepage = "http://wiki.opscode.com/display/chef"
+  s.homepage = "http://docs.chef.io/"
 
   s.add_dependency "chef", ">= 0.10.0"
+  s.add_dependency "extlib"
   s.add_dependency "google-api-client"
   s.add_dependency "multi_json"
   s.add_dependency "mixlib-config"

--- a/lib/google/compute/resource.rb
+++ b/lib/google/compute/resource.rb
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'extlib'
 require 'google/compute/exception'
-require 'multi_json'
 require 'google/compute/mixins/utils'
+require 'multi_json'
 
 module Google
   module Compute


### PR DESCRIPTION
For issue #44. Compatible with latest 'google-api-client' that requires 'extlib'. Fixes 'snake_case'.