### PR TITLE
New pd-ssd option, Gemfile updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+gemspec :name => "knife-google"
 
 group(:development, :test) do
   platforms :mswin, :mingw do
@@ -7,5 +8,3 @@ group(:development, :test) do
      gem "win32-service", "0.7.2"
   end
 end
-
-gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
-gemspec :name => "knife-google"
+
+gemspec
 
 group(:development, :test) do
   platforms :mswin, :mingw do

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This plugin utilizes Google Compute Engine API v1. Please review API v1
 [release notes](https://developers.google.com/compute/docs/release-notes#december032013)
 for additional information.
 
+With knife-google 1.4.0 Chef 12 is now utilized.
+
 With knife-google 1.3.0 options have changed. Several GCE specific short
 options have been deprecated and GCE specific long options now start
 with `--gce-`.

--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ $ knife google zone list
 $ knife google server list -Z us-central1-a
 
 # Create a server
-$ knife google server create www1 -m n1-standard-1 -I debian-7-wheezy-v20131120 -Z us-central1-a -i ~/.ssh/id_rsa -x jdoe
+$ knife google server create www1 -m n1-standard-1 -I centos-7-v20150127 -Z us-central1-a -x jdoe
 
 # Create a server with service account scopes
-$ knife google server create www1 -m n1-standard-1 -I debian-7-wheezy-v20131120 -Z us-central1-a -i ~/.ssh/id_rsa -x jdoe --gce-service-account-scopes https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/devstorage.full_control
+$ knife google server create www1 -m n1-standard-1 -I centos-7-v20150127 -Z us-central1-a -x jdoe --gce-service-account-scopes https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/devstorage.full_control
 
 # Delete a server (along with Chef node and API client via --purge)
 $ knife google server delete www1 --purge -Z us-central1-a
@@ -299,7 +299,7 @@ Google follow this naming convention:
 
 ```
 debian-7-wheezy-vYYYYMMDD
-centos-6-vYYYYMMDD
+centos-7-vYYYYMMDD
 ```
 
 By default, the plugin will look for the specified image in the instance's

--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.description = "Google Compute Engine Support for Chef's Knife Command"
   s.homepage = "http://docs.chef.io/"
 
-  s.add_runtime_dependency 'chef', '~> 12.0'
+  s.add_runtime_dependency 'chef', '~> 11.0'
   s.add_runtime_dependency 'extlib', '~> 0.9'
   s.add_runtime_dependency 'google-api-client' , '~> 0.8'
   s.add_runtime_dependency 'multi_json', '~> 1.10'

--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
   s.description = "Google Compute Engine Support for Chef's Knife Command"
   s.homepage = "http://docs.chef.io/"
 
-  s.add_runtime_dependency 'chef', '~> 12.0.3'
+  s.add_runtime_dependency 'chef', '~> 12.0'
   s.add_runtime_dependency 'extlib', '~> 0.9'
-  s.add_runtime_dependency 'google-api-client' , '~> 0.8.2'
+  s.add_runtime_dependency 'google-api-client' , '~> 0.8'
   s.add_runtime_dependency 'multi_json', '~> 1.10'
   s.add_runtime_dependency 'mixlib-config', '~> 2.0'
   s.files = `git ls-files`.split($/)

--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -15,15 +15,15 @@ Gem::Specification.new do |s|
   s.description = "Google Compute Engine Support for Chef's Knife Command"
   s.homepage = "http://docs.chef.io/"
 
-  s.add_runtime_dependency 'chef', '~> 11.0'
+  s.add_runtime_dependency 'chef'
   s.add_runtime_dependency 'extlib', '~> 0.9'
   s.add_runtime_dependency 'google-api-client' , '~> 0.8'
-  s.add_runtime_dependency 'multi_json', '~> 1.10'
-  s.add_runtime_dependency 'mixlib-config', '~> 2.0'
+  s.add_runtime_dependency 'multi_json'
+  s.add_runtime_dependency 'mixlib-config'
   s.files = `git ls-files`.split($/)
   #s.files = Dir['CONTRIB.md', 'Gemfile', 'LICENSE', 'README.md', 'Rakefile', 'knife-google.gemspec', 'lib/**/*', 'spec/**/*']
 
-  s.add_development_dependency 'rake', '~> 10.0'
-  s.add_development_dependency 'rspec', '~> 3.1'
-  s.add_development_dependency 'simplecov', '~> 0.9'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'simplecov'
 end

--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'extlib', '~> 0.9'
   s.add_runtime_dependency 'google-api-client' , '~> 0.8.2'
   s.add_runtime_dependency 'multi_json', '~> 1.10'
-  s.add_runtime_dependency 'mixlib-config', '~> 1.1'
+  s.add_runtime_dependency 'mixlib-config', '~> 2.0'
   s.files = `git ls-files`.split($/)
   #s.files = Dir['CONTRIB.md', 'Gemfile', 'LICENSE', 'README.md', 'Rakefile', 'knife-google.gemspec', 'lib/**/*', 'spec/**/*']
 

--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 require 'knife-google/version'
 
 Gem::Specification.new do |s|
-  s.name = "knife-google"
+  s.name = 'knife-google'
   s.version = Knife::Google::VERSION
   s.platform = Gem::Platform::RUBY
   s.authors = ["Chiraq Jog", "Ranjib Dey", "James Tucker", "Paul Rossman", "Eric Johnson"]
@@ -15,15 +15,16 @@ Gem::Specification.new do |s|
   s.description = "Google Compute Engine Support for Chef's Knife Command"
   s.homepage = "http://docs.chef.io/"
 
-  s.add_runtime_dependency 'chef'
-  s.add_runtime_dependency 'extlib', '~> 0.9'
-  s.add_runtime_dependency 'google-api-client' , '~> 0.8'
-  s.add_runtime_dependency 'multi_json'
-  s.add_runtime_dependency 'mixlib-config'
+  s.add_dependency 'chef', '~> 12.0'
+  s.add_dependency 'extlib', '~> 0.9'                 # google-api-ruby-client
+  s.add_dependency 'google-api-client', '~> 0.8'      # google-api-ruby-client
+  s.add_dependency 'mixlib-config', '~> 2.0'
+  s.add_dependency 'multi_json', '~> 1.10'            # google-api-ruby-client
+
   s.files = `git ls-files`.split($/)
   #s.files = Dir['CONTRIB.md', 'Gemfile', 'LICENSE', 'README.md', 'Rakefile', 'knife-google.gemspec', 'lib/**/*', 'spec/**/*']
 
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'rake', '~> 10.0'       # google-api-ruby-client
+  s.add_development_dependency 'rspec', '~> 3.1'       # google-api-ruby-client
+  s.add_development_dependency 'simplecov', '~> 0.9'   # google-api-ruby-client
 end

--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.description = "Google Compute Engine Support for Chef's Knife Command"
   s.homepage = "http://docs.chef.io/"
 
-  s.add_runtime_dependency 'chef', '~> 10.0'
+  s.add_runtime_dependency 'chef', '~> 12.0.3'
   s.add_runtime_dependency 'extlib', '~> 0.9'
   s.add_runtime_dependency 'google-api-client' , '~> 0.8.2'
   s.add_runtime_dependency 'multi_json', '~> 1.10'

--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -1,12 +1,13 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path('../lib', __FILE__)
 require 'knife-google/version'
 
 Gem::Specification.new do |s|
-  s.name = 'knife-google'
+  s.name = "knife-google"
   s.version = Knife::Google::VERSION
   s.platform = Gem::Platform::RUBY
   s.authors = ["Chiraq Jog", "Ranjib Dey", "James Tucker", "Paul Rossman", "Eric Johnson"]
+  s.license = "Apache-2.0"
   s.email = "paulrossman@google.com"
   s.has_rdoc = true
   s.extra_rdoc_files = ["README.md", "LICENSE", "CONTRIB.md" ]
@@ -14,15 +15,15 @@ Gem::Specification.new do |s|
   s.description = "Google Compute Engine Support for Chef's Knife Command"
   s.homepage = "http://docs.chef.io/"
 
-  s.add_dependency "chef", ">= 0.10.0"
-  s.add_dependency "extlib"
-  s.add_dependency "google-api-client"
-  s.add_dependency "multi_json"
-  s.add_dependency "mixlib-config"
+  s.add_runtime_dependency 'chef', '~> 10.0'
+  s.add_runtime_dependency 'extlib', '~> 0.9'
+  s.add_runtime_dependency 'google-api-client' , '~> 0.8.2'
+  s.add_runtime_dependency 'multi_json', '~> 1.10'
+  s.add_runtime_dependency 'mixlib-config', '~> 1.1'
   s.files = `git ls-files`.split($/)
   #s.files = Dir['CONTRIB.md', 'Gemfile', 'LICENSE', 'README.md', 'Rakefile', 'knife-google.gemspec', 'lib/**/*', 'spec/**/*']
 
-  s.add_development_dependency "rspec"
-  s.add_development_dependency "rake"
-  s.add_development_dependency "simplecov"
+  s.add_development_dependency 'rake', '~> 10.0'
+  s.add_development_dependency 'rspec', '~> 3.1'
+  s.add_development_dependency 'simplecov', '~> 0.9'
 end

--- a/lib/knife-google/version.rb
+++ b/lib/knife-google/version.rb
@@ -14,6 +14,6 @@
 #
 module Knife
   module Google
-    VERSION = "1.3.1"
+    VERSION = "1.3.2"
   end
 end

--- a/lib/knife-google/version.rb
+++ b/lib/knife-google/version.rb
@@ -14,6 +14,6 @@
 #
 module Knife
   module Google
-    VERSION = "1.3.2"
+    VERSION = "1.3.3"
   end
 end

--- a/lib/knife-google/version.rb
+++ b/lib/knife-google/version.rb
@@ -14,6 +14,6 @@
 #
 module Knife
   module Google
-    VERSION = "1.3.3"
+    VERSION = "1.4.0"
   end
 end

--- a/spec/chef/knife/google_server_create_spec.rb
+++ b/spec/chef/knife/google_server_create_spec.rb
@@ -36,10 +36,12 @@ describe Chef::Knife::GoogleServerCreate do
 
     sizeGb = 10
     disks = double(Google::Compute::ListableResourceCollection)
-    disks.should_receive(:insert).
-      with({:sourceImage => stored_image.self_link, :zone => stored_zone.name,
-            :name => stored_instance.name, :sizeGb => sizeGb}).
-      and_return(stored_disk)
+    disks.should_receive(:insert).with({
+      :sourceImage => stored_image.self_link,
+      :zone => stored_zone.name,
+      :name => stored_instance.name,
+      :type => "https://www.googleapis.com/compute/v1/projects/mock-project/zones/mock-zone/diskTypes/pd-standard",
+      :sizeGb => sizeGb}).and_return(stored_disk)
 
     networks = double(Google::Compute::ListableResourceCollection)
     networks.should_receive(:get).with(stored_network.name).
@@ -55,9 +57,9 @@ describe Chef::Knife::GoogleServerCreate do
 
     if additional_disk
       # Make sure we look for the disk
-      disks.should_receive(:list).exactly(1).
-        with({:zone => stored_zone.name, :name => "mock-disk"}).
-        and_return([stored_disk])
+      disks.should_receive(:list).exactly(1).with({
+        :zone => stored_zone.name,
+        :name => "mock-disk"}).and_return([stored_disk])
 
       # We're goign to create a second disk
       disk_params.push({
@@ -73,7 +75,7 @@ describe Chef::Knife::GoogleServerCreate do
       :name => stored_instance.name,
       :zone => stored_zone.name,
       :machineType => stored_machine_type.self_link,
-      #:image => stored_image.self_link,
+      :image => stored_image.self_link,
       :disks => disk_params,
       :networkInterfaces => [{
         "network" => stored_network.self_link,


### PR DESCRIPTION
Option to specify optional pd-ssd boot disk; default is pd-standard boot disk
Updated gem requirements, syncing with google-api-ruby-client
Changed Gemfile to use 'chef', '~> 12.0'