### PR TITLE
Fix "ERROR: TypeError: no implicit conversion of nil into String" 

### DIFF
--- a/lib/google/compute/zone_operation.rb
+++ b/lib/google/compute/zone_operation.rb
@@ -38,8 +38,8 @@ module Google
         @status_message = data["statusMessage"]
         @user = data["user"]
         @progress =  data["progress"]
-        @insert_time = Time.parse( data["insertTime"] )
-        @start_time = Time.parse( data["startTime"] )
+        @insert_time = Time.parse( data["insertTime"] ) if data.key?("insertTime")
+        @start_time = Time.parse( data["startTime"] ) if data.key?("startTime")
         @end_time = Time.parse( data["endTime"] ) if data.key?("endTime")
         @error = data["error"]
         @warnings = data["warnings"]


### PR DESCRIPTION
Fix "ERROR: TypeError: no implicit conversion of nil into String" resulting from trying to parse non-existent startTime and insertTime attributes in the results of certain operations (i.e., "google knife server create").