### PR TITLE
server create support for additional Linux-based operating systems

### DIFF
--- a/lib/chef/knife/google_server_create.rb
+++ b/lib/chef/knife/google_server_create.rb
@@ -419,14 +419,25 @@ class Chef
               image = client.images.get(:project=>project, :name=>config[:image]).self_link
             else
               case config[:image].downcase
-              when /debian/
-                project = 'debian-cloud'
-                ui.info("Looking for Image '#{config[:image]}' in Project '#{project}'")
               when /centos/
                 project = 'centos-cloud'
-                ui.info("Looking for Image '#{config[:image]}' in Project '#{project}'")
+             when /container-vm/
+                project = 'google-containers'
+             when /coreos/
+                project = 'coreos-cloud'
+              when /debian/
+                project = 'debian-cloud'
+             when /opensuse-cloud/
+                project = 'opensuse-cloud'
+              when /rhel/
+                project = 'rhel-cloud'
+              when /sles/
+                project = 'suse-cloud'
+              when /ubuntu/
+                project = 'ubuntu-os-cloud'
               end
               checked_all = true
+              ui.info("Looking for Image '#{config[:image]}' in Project '#{project}'")
               image = client.images.get(:project=>project, :name=>config[:image]).self_link
             end
           else

--- a/lib/knife-google/version.rb
+++ b/lib/knife-google/version.rb
@@ -14,6 +14,6 @@
 #
 module Knife
   module Google
-    VERSION = "1.4.1"
+    VERSION = "1.4.2"
   end
 end


### PR DESCRIPTION
Compute Engine provides a number of Linux-based operating systems that can be used. Added "knife google server create" operating system support for: 
 coreos
 container-vm
 opensuse
 rhel
 sles
 ubuntu

https://cloud.google.com/compute/docs/operating-systems/linux-os

This resolves issue #59 