### PR TITLE
Error in metadata parsing while creating a compute instance

### DIFF
--- a/lib/chef/knife/google_server_create.rb
+++ b/lib/chef/knife/google_server_create.rb
@@ -537,7 +537,7 @@ class Chef
         metadata_items = []
 
         locate_config_value(:gce_metadata).collect do |pair|
-          mkey, mvalue = pair.split('=')
+          mkey, mvalue = pair.split('=',2)
           metadata_items << {'key' => mkey, 'value' => mvalue}
         end
 

--- a/spec/chef/knife/google_server_create_spec.rb
+++ b/spec/chef/knife/google_server_create_spec.rb
@@ -152,6 +152,20 @@ describe Chef::Knife::GoogleServerCreate do
     @server_instance.run
   end
 
+  it "should correctly parse gce metadata" do
+    setup
+    sshKeys = "user:ssh-rsa blah,blah== me@example"
+    @server_instance.config[:gce_public_ip]='EPHEMERAL'
+    @server_instance.config[:gce_metadata]=["sshKeys=#{sshKeys}"]
+    allow(@server_instance.ui).to receive(:info)
+    allow(@server_instance).to receive(:wait_for_disk)
+    allow(@server_instance).to receive(:wait_for_sshd)
+    expect(@server_instance).to receive(:bootstrap_for_node).with(stored_instance,'10.100.0.10').and_return(double("Chef::Knife::Bootstrap",:run => true))
+    @result[:metadata]["items"] = [{"key"=>"sshKeys", "value"=>sshKeys}]
+    expect(@instances).to receive(:create).with(@result).and_return(stored_zone_operation)
+    @server_instance.run
+  end
+
   it "create with public ip set to none" do
     setup
     @result = {


### PR DESCRIPTION
I am trying to create a new instance, and passing sshKeys as metadata.
My ssh public key has "=" a character, due to which metadata was not getting updated properly

```
 --gce-metadata sshKeys="user:ssh-rsa blah,blah== me@example
```

But when instance is getting created it has
```
ssh-rsa blah,blah
```
as ssh key and drops **"== me@example"** at the end