### PR TITLE
Updated ffi and win32-service versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ gemspec
 
 group(:development, :test) do
   platforms :mswin, :mingw do
-     gem "ffi", "1.3.1"
+     gem "ffi", "~> 1.9.0"
      gem "rdp-ruby-wmi", "0.3.1"
-     gem "win32-service", "0.7.2"
+     gem "win32-service", "~> 0.8.6"
   end
 end


### PR DESCRIPTION
Fixed gem dependency error while doing bundle install.  This was found while trying to reproduce https://github.com/chef/knife-google/issues/87 on master. Confirmed that issue is not exist on master with windows OS.