### PR TITLE
adding support for preemptible GCE instances

### DIFF
--- a/lib/chef/knife/cloud/google_service.rb
+++ b/lib/chef/knife/cloud/google_service.rb
@@ -191,7 +191,7 @@ class Chef::Knife::Cloud
     end
 
     def check_api_call(&block)
-      block.call
+      yield
     rescue Google::Apis::ClientError
       false
     else
@@ -353,8 +353,9 @@ class Chef::Knife::Cloud
 
     def instance_scheduling_for(options)
       scheduling = Google::Apis::ComputeV1::Scheduling.new
-      scheduling.automatic_restart = options[:auto_restart].to_s
+      scheduling.automatic_restart   = options[:auto_restart].to_s
       scheduling.on_host_maintenance = migrate_setting_for(options[:auto_migrate])
+      scheduling.preemptible         = options[:preemptible].to_s
 
       scheduling
     end
@@ -472,7 +473,7 @@ class Chef::Knife::Cloud
       begin
         Timeout.timeout(wait_time) do
           loop do
-            item = block.call
+            item = yield
             current_status = item.status
 
             if current_status == requested_status

--- a/spec/cloud/google_service_spec.rb
+++ b/spec/cloud/google_service_spec.rb
@@ -567,12 +567,13 @@ describe Chef::Knife::Cloud::GoogleService do
   describe '#instance_scheduling_for' do
     it "returns a properly-formatted scheduling object" do
       scheduling = double("scheduling")
-      options    = { auto_restart: "auto_restart", auto_migrate: "auto_migrate" }
+      options    = { auto_restart: "auto_restart", auto_migrate: "auto_migrate", preemptible: "preempt" }
 
       expect(service).to receive(:migrate_setting_for).with("auto_migrate").and_return("host_maintenance")
       expect(Google::Apis::ComputeV1::Scheduling).to receive(:new).and_return(scheduling)
       expect(scheduling).to receive(:automatic_restart=).with("auto_restart")
       expect(scheduling).to receive(:on_host_maintenance=).with("host_maintenance")
+      expect(scheduling).to receive(:preemptible=).with("preempt")
 
       expect(service.instance_scheduling_for(options)).to eq(scheduling)
     end

--- a/spec/google_server_create_spec.rb
+++ b/spec/google_server_create_spec.rb
@@ -152,6 +152,39 @@ describe Chef::Knife::Cloud::GoogleServerCreate do
     end
   end
 
+  describe '#preemptible?' do
+    it "returns the preemptible setting from the config" do
+      expect(command).to receive(:locate_config_value).with(:preemptible).and_return("test_preempt")
+      expect(command.preemptible?).to eq("test_preempt")
+    end
+  end
+
+  describe '#auto_migrate?' do
+    it "returns false if the instance is preemptible" do
+      expect(command).to receive(:preemptible?).and_return(true)
+      expect(command.auto_migrate?).to eq(false)
+    end
+
+    it "returns the setting from the config if preemptible is false" do
+      expect(command).to receive(:preemptible?).and_return(false)
+      expect(command).to receive(:locate_config_value).with(:auto_migrate).and_return("test_migrate")
+      expect(command.auto_migrate?).to eq("test_migrate")
+    end
+  end
+
+  describe '#auto_restart?' do
+    it "returns false if the instance is preemptible" do
+      expect(command).to receive(:preemptible?).and_return(true)
+      expect(command.auto_restart?).to eq(false)
+    end
+
+    it "returns the setting from the config if preemptible is false" do
+      expect(command).to receive(:preemptible?).and_return(false)
+      expect(command).to receive(:locate_config_value).with(:auto_restart).and_return("test_restart")
+      expect(command.auto_restart?).to eq("test_restart")
+    end
+  end
+
   describe '#ip_address_for_bootstrap' do
     it "returns the public IP by default" do
       expect(command).to receive(:locate_config_value).with(:use_private_ip).and_return(false)

--- a/spec/google_server_create_spec.rb
+++ b/spec/google_server_create_spec.rb
@@ -38,8 +38,13 @@ describe Chef::Knife::Cloud::GoogleServerCreate do
       allow(command).to receive(:check_for_missing_config_values!)
       allow(command).to receive(:valid_disk_size?).and_return(true)
       allow(command).to receive(:boot_disk_size)
-      command.config[:bootstrap_protocol] = "ssh"
-      command.config[:identity_file] = "/path/to/file"
+      allow(command).to receive(:locate_config_value).with(:bootstrap_protocol).and_return("ssh")
+      allow(command).to receive(:locate_config_value).with(:identity_file).and_return("/path/to/file")
+      allow(command).to receive(:locate_config_value).with(:auto_migrate)
+      allow(command).to receive(:locate_config_value).with(:auto_restart)
+      allow(command).to receive(:locate_config_value).with(:chef_node_name)
+      allow(command).to receive(:locate_config_value).with(:chef_node_name_prefix)
+      allow(command).to receive(:preemptible?).and_return(false)
     end
 
     context "when no instance name has been provided" do
@@ -65,6 +70,20 @@ describe Chef::Knife::Cloud::GoogleServerCreate do
       expect(command).to receive(:locate_config_value).with(:bootstrap_protocol).and_return("winrm")
       expect(command).to receive(:locate_config_value).with(:gce_email).and_return(nil)
       expect { command.validate_params! }.to raise_error(RuntimeError)
+    end
+
+    it "prints a warning if auto-migrate is true for a preemptible instance" do
+      allow(command).to receive(:preemptible?).and_return(true)
+      allow(command).to receive(:locate_config_value).with(:auto_migrate).and_return(true)
+      expect(command.ui).to receive(:warn).with("Auto-migrate disabled for preemptible instance")
+      command.validate_params!
+    end
+
+    it "prints a warning if auto-restart is true for a preemptible instance" do
+      allow(command).to receive(:preemptible?).and_return(true)
+      allow(command).to receive(:locate_config_value).with(:auto_restart).and_return(true)
+      expect(command.ui).to receive(:warn).with("Auto-restart disabled for preemptible instance")
+      command.validate_params!
     end
   end
 


### PR DESCRIPTION
This change adds a `--gce-preemptible` option that will flag the instance as a preemptible instance and disable auto-migrate and auto-restart. Users can choose to use this for instances where the user doesn't care if they go away and thus pay less for the instance.

Also fixes a few rubocop issues from latest chefstyle.

Fixes #72.