### PR TITLE
make public_ip work for any case 'none' at 'instance_access_configs_for'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-- 2.0.0
 - 2.1
 - 2.2
+- 2.3
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: false
 rvm:
 - 2.1
 - 2.2
-- 2.3
 branches:
   only:
   - master

--- a/lib/chef/knife/cloud/google_service.rb
+++ b/lib/chef/knife/cloud/google_service.rb
@@ -404,7 +404,9 @@ class Chef::Knife::Cloud
     end
 
     def instance_access_configs_for(public_ip)
-      return [] if public_ip.nil? || public_ip == "NONE"
+      public_ip.downcase! if public_ip.respond_to?(:downcase)
+
+      return [] if public_ip.nil? || public_ip == "none"
 
       access_config = Google::Apis::ComputeV1::AccessConfig.new
       access_config.name = "External NAT"

--- a/spec/cloud/google_service_spec.rb
+++ b/spec/cloud/google_service_spec.rb
@@ -682,24 +682,24 @@ describe Chef::Knife::Cloud::GoogleService do
 
     context "for None public_ip" do
       it "empty public_ip none|None|NONE|~" do
-        expect(service.instance_access_configs_for('none')).to eq([])
+        expect(service.instance_access_configs_for("none")).to eq([])
 
-        expect(service.instance_access_configs_for('None')).to eq([])
+        expect(service.instance_access_configs_for("None")).to eq([])
 
-        expect(service.instance_access_configs_for('NONE')).to eq([])
+        expect(service.instance_access_configs_for("NONE")).to eq([])
       end
     end
 
     context "for valid public_ip" do
       it "valid public_ip" do
-        access_config = service.instance_access_configs_for('8.8.8.8')
-        expect(access_config.first.nat_ip).to eq('8.8.8.8')
+        access_config = service.instance_access_configs_for("8.8.8.8")
+        expect(access_config.first.nat_ip).to eq("8.8.8.8")
       end
     end
 
     context "for invalid public_ip" do
       it "empty public_ip none|None|NONE|~" do
-        access_config = service.instance_access_configs_for('oh no not a valid IP')
+        access_config = service.instance_access_configs_for("oh no not a valid IP")
         expect(access_config.first.nat_ip).to eq(nil)
       end
     end

--- a/spec/cloud/google_service_spec.rb
+++ b/spec/cloud/google_service_spec.rb
@@ -677,7 +677,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#instance_access_configs_for' do
+  describe "#instance_access_configs_for" do
     let(:interface) { double("interface" ) }
 
     context "for None public_ip" do
@@ -705,7 +705,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#network_url_for' do
+  describe "#network_url_for" do
     it "returns a properly-formatted network URL" do
       expect(service.network_url_for("test_network")).to eq("projects/test_project/global/networks/test_network")
     end

--- a/spec/cloud/google_service_spec.rb
+++ b/spec/cloud/google_service_spec.rb
@@ -677,6 +677,34 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
+  describe '#instance_access_configs_for' do
+    let(:interface) { double("interface" ) }
+
+    context "for None public_ip" do
+      it "empty public_ip none|None|NONE|~" do
+        expect(service.instance_access_configs_for('none')).to eq([])
+
+        expect(service.instance_access_configs_for('None')).to eq([])
+
+        expect(service.instance_access_configs_for('NONE')).to eq([])
+      end
+    end
+
+    context "for valid public_ip" do
+      it "valid public_ip" do
+        access_config = service.instance_access_configs_for('8.8.8.8')
+        expect(access_config.first.nat_ip).to eq('8.8.8.8')
+      end
+    end
+
+    context "for invalid public_ip" do
+      it "empty public_ip none|None|NONE|~" do
+        access_config = service.instance_access_configs_for('oh no not a valid IP')
+        expect(access_config.first.nat_ip).to eq(nil)
+      end
+    end
+  end
+
   describe '#network_url_for' do
     it "returns a properly-formatted network URL" do
       expect(service.network_url_for("test_network")).to eq("projects/test_project/global/networks/test_network")


### PR DESCRIPTION
version in use: knife-google (2.0.0)

Running `knife google server create ...--gce-public-ip none` command still attached Ephemeral(default) public-ip to the new node. 
Making match non-case-sensitive at 'google_service.rb:instance_access_configs_for' fixed it.

Here is the PR for it, also made it similar to 'valid_public_ip_setting?' handling of case.