### PR TITLE
v2.2.1: Version bump + Travis Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-- 2.0.0
-- 2.1
-- 2.2
+- 2.1.10
+- 2.2.5
+- 2.3.1
+- ruby-head
 branches:
   only:
   - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # knife-google Change Log
 
-## v2.2.0 (2016-03-17)
 
+## v2.2.1 (2016-08-23)
+ * [pr#109](https://github.com/chef/knife-google/pull/109) Add aliases to match image families and add Ubuntu 16.04
+
+## v2.2.0 (2016-03-17)
  * [pr#102](https://github.com/chef/knife-google/pull/102) Added support for preemptible instances
  * [pr#103](https://github.com/chef/knife-google/pull/103) Added support for deploying instances on subnetworks
  * [pr#103](https://github.com/chef/knife-google/pull/104) Added gcloud-style image aliases (i.e. image "centos-7" will get you the latest CentOS 7 disk image)

--- a/lib/knife-google/version.rb
+++ b/lib/knife-google/version.rb
@@ -14,7 +14,7 @@
 #
 module Knife
   module Google
-    VERSION = "2.2.0".freeze
+    VERSION = "2.2.1".freeze
     MAJOR, MINOR, TINY = VERSION.split(".")
   end
 end

--- a/spec/cloud/google_service_helpers_spec.rb
+++ b/spec/cloud/google_service_helpers_spec.rb
@@ -26,7 +26,7 @@ end
 describe Chef::Knife::Cloud::GoogleServiceHelpers do
   let(:tester) { Tester.new }
 
-  describe '#create_service_instance' do
+  describe "#create_service_instance" do
     it "creates a GoogleService instance" do
       expect(tester).to receive(:locate_config_value).with(:gce_project).and_return("test_project")
       expect(tester).to receive(:locate_config_value).with(:gce_zone).and_return("test_zone")
@@ -48,7 +48,7 @@ describe Chef::Knife::Cloud::GoogleServiceHelpers do
     end
   end
 
-  describe '#check_for_missing_config_values' do
+  describe "#check_for_missing_config_values" do
     it "does not raise an exception if all parameters are present" do
       expect(tester).to receive(:locate_config_value).with(:gce_project).and_return("project")
       expect(tester).to receive(:locate_config_value).with(:gce_zone).and_return("zone")
@@ -70,7 +70,7 @@ describe Chef::Knife::Cloud::GoogleServiceHelpers do
     end
   end
 
-  describe '#private_ip_for' do
+  describe "#private_ip_for" do
     it "returns the IP address if it exists" do
       network_interface = double("network_interface", network_ip: "1.2.3.4")
       server            = double("server", network_interfaces: [network_interface])
@@ -86,7 +86,7 @@ describe Chef::Knife::Cloud::GoogleServiceHelpers do
     end
   end
 
-  describe '#public_ip_for' do
+  describe "#public_ip_for" do
     it "returns the IP address if it exists" do
       access_config     = double("access_config", nat_ip: "4.3.2.1")
       network_interface = double("network_interface", access_configs: [access_config])
@@ -104,7 +104,7 @@ describe Chef::Knife::Cloud::GoogleServiceHelpers do
     end
   end
 
-  describe '#valid_disk_size?' do
+  describe "#valid_disk_size?" do
     it "returns true if the disk is between 10 and 10,000" do
       expect(tester.valid_disk_size?(50)).to eq(true)
     end

--- a/spec/cloud/google_service_spec.rb
+++ b/spec/cloud/google_service_spec.rb
@@ -65,7 +65,7 @@ describe Chef::Knife::Cloud::GoogleService do
     allow(service).to receive(:connection).and_return(connection)
   end
 
-  describe '#connection' do
+  describe "#connection" do
     it "returns a properly configured ComputeService" do
       compute_service = double("compute_service")
       client_options  = double("client_options")
@@ -85,7 +85,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#authorization' do
+  describe "#authorization" do
     it "returns a Google::Auth authorization object" do
       auth_object = double("auth_object")
       expect(Google::Auth).to receive(:get_application_default).and_return(auth_object)
@@ -93,7 +93,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#create_server' do
+  describe "#create_server" do
     it "creates and returns the created instance" do
       create_instance_obj = double("instance_obj")
       create_options      = { name: "test_instance" }
@@ -110,7 +110,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#delete_server' do
+  describe "#delete_server" do
     context "when the instance does not exist" do
       before do
         allow(service.ui).to receive(:warn)
@@ -144,29 +144,29 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#get_server' do
+  describe "#get_server" do
     it "returns an instance" do
       expect(connection).to receive(:get_instance).with(project, zone, "test_instance").and_return("instance")
       expect(service.get_server("test_instance")).to eq("instance")
     end
   end
 
-  describe '#list_zones' do
+  describe "#list_zones" do
     subject { service.list_zones }
     it_behaves_like "a paginated list fetcher", :list_zones, :items, "test_project"
   end
 
-  describe '#list_disks' do
+  describe "#list_disks" do
     subject { service.list_disks }
     it_behaves_like "a paginated list fetcher", :list_disks, :items, "test_project", "test_zone"
   end
 
-  describe '#list_regions' do
+  describe "#list_regions" do
     subject { service.list_regions }
     it_behaves_like "a paginated list fetcher", :list_regions, :items, "test_project"
   end
 
-  describe '#list_project_quotas' do
+  describe "#list_project_quotas" do
     let(:response) { double("response") }
 
     before do
@@ -185,7 +185,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#validate_server_create_options!' do
+  describe "#validate_server_create_options!" do
     let(:options) do
       {
         machine_type:  "test_type",
@@ -235,13 +235,13 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#check_api_call' do
+  describe "#check_api_call" do
     it "returns false if the block raises a ClientError" do
       expect(service.check_api_call { raise Google::Apis::ClientError.new("whoops") }).to eq(false)
     end
 
     it "raises an exception if the block raises something other than a ClientError" do
-      expect { service.check_api_call { raise RuntimeError.new("whoops") } }.to raise_error(RuntimeError)
+      expect { service.check_api_call { raise "whoops" } }.to raise_error(RuntimeError)
     end
 
     it "returns true if the block does not raise an exception" do
@@ -249,7 +249,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#valid_machine_type?' do
+  describe "#valid_machine_type?" do
     it "returns false if no matchine type was specified" do
       expect(service.valid_machine_type?(nil)).to eq(false)
     end
@@ -262,7 +262,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#valid_network?' do
+  describe "#valid_network?" do
     it "returns false if no network was specified" do
       expect(service.valid_network?(nil)).to eq(false)
     end
@@ -275,7 +275,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#valid_subnet?' do
+  describe "#valid_subnet?" do
     it "returns false if no subnet was specified" do
       expect(service.valid_subnet?(nil)).to eq(false)
     end
@@ -289,7 +289,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#image_exist?' do
+  describe "#image_exist?" do
     it "checks the image using check_api_call" do
       expect(connection).to receive(:get_image).with("image_project", "image_name")
       expect(service).to receive(:check_api_call).and_call_original
@@ -298,7 +298,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#valid_public_ip_setting?' do
+  describe "#valid_public_ip_setting?" do
     it "returns true if the public_ip is nil" do
       expect(service.valid_public_ip_setting?(nil)).to eq(true)
     end
@@ -322,7 +322,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#valid_ip_address' do
+  describe "#valid_ip_address" do
     it "returns false if IPAddr is unable to parse the address" do
       expect(IPAddr).to receive(:new).with("not_an_ip").and_raise(IPAddr::InvalidAddressError)
       expect(service.valid_ip_address?("not_an_ip")).to eq(false)
@@ -334,7 +334,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#region' do
+  describe "#region" do
     it "returns the region for a given zone" do
       zone_obj = double("zone_obj", region: "/path/to/test_region")
       expect(connection).to receive(:get_zone).with(project, zone).and_return(zone_obj)
@@ -342,7 +342,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#instance_object_for' do
+  describe "#instance_object_for" do
     let(:instance_object) { double("instance_object") }
     let(:options) do
       {
@@ -387,7 +387,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#instance_disks_for' do
+  describe "#instance_disks_for" do
 
     before do
       expect(service).to receive(:instance_boot_disk_for).with(options).and_return("boot_disk")
@@ -433,7 +433,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#instance_boot_disk_for' do
+  describe "#instance_boot_disk_for" do
     it "sets up a disk object and returns it" do
       disk    = double("disk")
       params  = double("params")
@@ -464,7 +464,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#boot_disk_type_for' do
+  describe "#boot_disk_type_for" do
     it "returns pd-ssd if boot_disk_ssd is true" do
       expect(service.boot_disk_type_for(boot_disk_ssd: true)).to eq("pd-ssd")
     end
@@ -474,7 +474,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#image_search_for' do
+  describe "#image_search_for" do
     context "when the user supplies an image project" do
       it "returns the image URL based on the image project" do
         expect(service).to receive(:image_url_for).with("test_project", "test_image").and_return("image_url")
@@ -527,7 +527,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#image_url_for' do
+  describe "#image_url_for" do
     it "returns nil if the image does not exist" do
       expect(service).to receive(:image_exist?).with("image_project", "image_name").and_return(false)
       expect(service.image_url_for("image_project", "image_name")).to eq(nil)
@@ -539,7 +539,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#image_alias_url' do
+  describe "#image_alias_url" do
     context "when the image_alias is not a valid alias" do
       it "returns nil" do
         expect(service.image_alias_url("fake_alias")).to eq(nil)
@@ -583,7 +583,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#boot_disk_name_for' do
+  describe "#boot_disk_name_for" do
     it "returns the boot disk name if supplied by the user" do
       options = { name: "instance_name", boot_disk_name: "disk_name" }
       expect(service.boot_disk_name_for(options)).to eq("disk_name")
@@ -595,13 +595,13 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#machine_type_url_for' do
+  describe "#machine_type_url_for" do
     it "returns a properly-formatted machine type URL" do
       expect(service.machine_type_url_for("test_type")).to eq("zones/test_zone/machineTypes/test_type")
     end
   end
 
-  describe '#instance_metadata_for' do
+  describe "#instance_metadata_for" do
     it "returns nil if the passed-in metadata is nil" do
       expect(service.instance_metadata_for(nil)).to eq(nil)
     end
@@ -629,7 +629,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#instance_network_interfaces_for' do
+  describe "#instance_network_interfaces_for" do
     let(:interface) { double("interface" ) }
     let(:options)   { { network: "test_network", public_ip: "public_ip" } }
 
@@ -677,20 +677,20 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#network_url_for' do
+  describe "#network_url_for" do
     it "returns a properly-formatted network URL" do
       expect(service.network_url_for("test_network")).to eq("projects/test_project/global/networks/test_network")
     end
   end
 
-  describe '#subnet_url_for' do
+  describe "#subnet_url_for" do
     it "returns a properly-formatted subnet URL" do
       expect(service).to receive(:region).and_return("test_region")
       expect(service.subnet_url_for("test_subnet")).to eq("projects/test_project/regions/test_region/subnetworks/test_subnet")
     end
   end
 
-  describe '#instance_scheduling_for' do
+  describe "#instance_scheduling_for" do
     it "returns a properly-formatted scheduling object" do
       scheduling = double("scheduling")
       options    = { auto_restart: "auto_restart", auto_migrate: "auto_migrate", preemptible: "preempt" }
@@ -705,7 +705,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#migrate_setting_for' do
+  describe "#migrate_setting_for" do
     it "returns MIGRATE when auto_migrate is true" do
       expect(service.migrate_setting_for(true)).to eq("MIGRATE")
     end
@@ -715,7 +715,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#instance_service_accounts_for' do
+  describe "#instance_service_accounts_for" do
     it "returns nil if service_account_scopes is nil" do
       expect(service.instance_service_accounts_for({})).to eq(nil)
     end
@@ -741,7 +741,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#service_account_scope_url' do
+  describe "#service_account_scope_url" do
     it "returns the passed-in scope if it already looks like a scope URL" do
       scope = "https://www.googleapis.com/auth/fake_scope"
       expect(service.service_account_scope_url(scope)).to eq(scope)
@@ -753,7 +753,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#translate_scope_alias' do
+  describe "#translate_scope_alias" do
     it "returns a scope for a given alias" do
       expect(service.translate_scope_alias("storage-rw")).to eq("devstorage.read_write")
     end
@@ -763,7 +763,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#instance_tags_for' do
+  describe "#instance_tags_for" do
     it "returns nil if tags is nil" do
       expect(service.instance_tags_for(nil)).to eq(nil)
     end
@@ -782,7 +782,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#network_for' do
+  describe "#network_for" do
     it "returns the network name if it exists" do
       interface = double("interface", network: "/some/path/to/default_network")
       instance = double("instance", network_interfaces: [interface])
@@ -798,14 +798,14 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#machine_type_for' do
+  describe "#machine_type_for" do
     it "returns the machine type name" do
       instance = double("instance", machine_type: "/some/path/to/test_type")
       expect(service.machine_type_for(instance)).to eq("test_type")
     end
   end
 
-  describe '#public_project_for_image' do
+  describe "#public_project_for_image" do
     {
       "centos"         => "centos-cloud",
       "container-vm"   => "google-containers",
@@ -823,13 +823,13 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#disk_type_url_for' do
+  describe "#disk_type_url_for" do
     it "returns a properly-formatted disk type URL" do
       expect(service.disk_type_url_for("disk_type")).to eq("zones/test_zone/diskTypes/disk_type")
     end
   end
 
-  describe '#paginated_results' do
+  describe "#paginated_results" do
     let(:response)      { double("response") }
     let(:api_method)    { :list_stuff }
     let(:items_method)  { :items }
@@ -893,7 +893,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#wait_for_status' do
+  describe "#wait_for_status" do
     let(:item) { double("item") }
 
     before do
@@ -940,7 +940,7 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#wait_for_operation' do
+  describe "#wait_for_operation" do
     let(:operation) { double("operation", name: "operation-123") }
 
     it "raises a properly-formatted exception when errors exist" do
@@ -963,14 +963,14 @@ describe Chef::Knife::Cloud::GoogleService do
     end
   end
 
-  describe '#zone_operation' do
+  describe "#zone_operation" do
     it "fetches the operation from the API and returns it" do
       expect(connection).to receive(:get_zone_operation).with(project, zone, "operation-123").and_return("operation")
       expect(service.zone_operation("operation-123")).to eq("operation")
     end
   end
 
-  describe '#operation_errors' do
+  describe "#operation_errors" do
     let(:operation) { double("operation") }
     let(:error_obj) { double("error_obj") }
 

--- a/spec/google_disk_create_spec.rb
+++ b/spec/google_disk_create_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Knife::Cloud::GoogleDiskCreate do
 
   it_behaves_like Chef::Knife::Cloud::Command, described_class.new
 
-  describe '#validate_params!' do
+  describe "#validate_params!" do
     before do
       allow(command).to receive(:check_for_missing_config_values!)
       allow(command).to receive(:valid_disk_size?).and_return(true)
@@ -59,7 +59,7 @@ describe Chef::Knife::Cloud::GoogleDiskCreate do
     end
   end
 
-  describe '#execute_command' do
+  describe "#execute_command" do
     it "calls the service to create the disk" do
       expect(command).to receive(:locate_config_value).with(:disk_size).and_return("size")
       expect(command).to receive(:locate_config_value).with(:disk_type).and_return("type")

--- a/spec/google_disk_delete_spec.rb
+++ b/spec/google_disk_delete_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Knife::Cloud::GoogleDiskDelete do
 
   it_behaves_like Chef::Knife::Cloud::Command, described_class.new
 
-  describe '#validate_params!' do
+  describe "#validate_params!" do
     before do
       allow(command).to receive(:check_for_missing_config_values!)
     end
@@ -53,7 +53,7 @@ describe Chef::Knife::Cloud::GoogleDiskDelete do
     end
   end
 
-  describe '#execute_command' do
+  describe "#execute_command" do
     it "calls the service to delete each disk" do
       expect(service).to receive(:delete_disk).with("disk1")
       expect(service).to receive(:delete_disk).with("disk2")

--- a/spec/google_disk_list_spec.rb
+++ b/spec/google_disk_list_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Knife::Cloud::GoogleDiskList do
 
   it_behaves_like Chef::Knife::Cloud::Command, described_class.new
 
-  describe '#validate_params!' do
+  describe "#validate_params!" do
     it "checks for missing config values" do
       expect(command).to receive(:check_for_missing_config_values!)
 
@@ -38,14 +38,14 @@ describe Chef::Knife::Cloud::GoogleDiskList do
     end
   end
 
-  describe '#query_resource' do
+  describe "#query_resource" do
     it "uses the service to list disks" do
       expect(service).to receive(:list_disks).and_return("disks")
       expect(command.query_resource).to eq("disks")
     end
   end
 
-  describe '#format_status_value' do
+  describe "#format_status_value" do
     it "returns green when the status is ready" do
       expect(command.ui).to receive(:color).with("ready", :green)
       command.format_status_value("ready")
@@ -57,13 +57,13 @@ describe Chef::Knife::Cloud::GoogleDiskList do
     end
   end
 
-  describe '#format_disk_type' do
+  describe "#format_disk_type" do
     it "returns a properly-formatted disk type" do
       expect(command.format_disk_type("a/b/c/disk_type")).to eq("disk_type")
     end
   end
 
-  describe '#format_source_image' do
+  describe "#format_source_image" do
     it "returns 'unknown' if the source is nil" do
       expect(command.format_source_image(nil)).to eq("unknown")
     end
@@ -77,7 +77,7 @@ describe Chef::Knife::Cloud::GoogleDiskList do
     end
   end
 
-  describe '#format_users' do
+  describe "#format_users" do
     it "returns 'unknown' if the source is nil" do
       expect(command.format_users(nil)).to eq("none")
     end

--- a/spec/google_project_quotas_spec.rb
+++ b/spec/google_project_quotas_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Knife::Cloud::GoogleProjectQuotas do
 
   it_behaves_like Chef::Knife::Cloud::Command, described_class.new
 
-  describe '#validate_params!' do
+  describe "#validate_params!" do
     it "checks for missing config values" do
       expect(command).to receive(:check_for_missing_config_values!)
 
@@ -38,20 +38,20 @@ describe Chef::Knife::Cloud::GoogleProjectQuotas do
     end
   end
 
-  describe '#query_resource' do
+  describe "#query_resource" do
     it "uses the service to list project quotas" do
       expect(service).to receive(:list_project_quotas).and_return("quotas")
       expect(command.query_resource).to eq("quotas")
     end
   end
 
-  describe '#format_name' do
+  describe "#format_name" do
     it "returns a properly-formatted name" do
       expect(command.format_name("something_cool_here")).to eq("Something Cool Here")
     end
   end
 
-  describe '#format_number' do
+  describe "#format_number" do
     it "returns an integer as a string if the number is a whole number" do
       expect(command.format_number(2.0)).to eq("2")
     end

--- a/spec/google_region_list_spec.rb
+++ b/spec/google_region_list_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Knife::Cloud::GoogleRegionList do
 
   it_behaves_like Chef::Knife::Cloud::Command, described_class.new
 
-  describe '#validate_params!' do
+  describe "#validate_params!" do
     it "checks for missing config values" do
       expect(command).to receive(:check_for_missing_config_values!)
 
@@ -38,14 +38,14 @@ describe Chef::Knife::Cloud::GoogleRegionList do
     end
   end
 
-  describe '#query_resource' do
+  describe "#query_resource" do
     it "uses the service to list regions" do
       expect(service).to receive(:list_regions).and_return("regions")
       expect(command.query_resource).to eq("regions")
     end
   end
 
-  describe '#format_status_value' do
+  describe "#format_status_value" do
     it "returns green when the status is up" do
       expect(command.ui).to receive(:color).with("up", :green)
       command.format_status_value("up")
@@ -57,7 +57,7 @@ describe Chef::Knife::Cloud::GoogleRegionList do
     end
   end
 
-  describe '#format_zones' do
+  describe "#format_zones" do
     it "returns properly-formatted zones" do
       expect(command.format_zones(["a/b/zone1", "c/d/zone2"])).to eq("zone1, zone2")
     end

--- a/spec/google_region_quotas_spec.rb
+++ b/spec/google_region_quotas_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Knife::Cloud::GoogleRegionQuotas do
 
   it_behaves_like Chef::Knife::Cloud::Command, described_class.new
 
-  describe '#validate_params!' do
+  describe "#validate_params!" do
     it "checks for missing config values" do
       expect(command).to receive(:check_for_missing_config_values!)
 
@@ -38,7 +38,7 @@ describe Chef::Knife::Cloud::GoogleRegionQuotas do
     end
   end
 
-  describe '#execute_command' do
+  describe "#execute_command" do
     let(:ui)      { double("ui") }
     let(:regions) { [region1] }
 
@@ -90,13 +90,13 @@ describe Chef::Knife::Cloud::GoogleRegionQuotas do
     end
   end
 
-  describe '#format_name' do
+  describe "#format_name" do
     it "returns a properly-formatted name" do
       expect(command.format_name("something_cool_here")).to eq("Something Cool Here")
     end
   end
 
-  describe '#format_number' do
+  describe "#format_number" do
     it "returns an integer as a string if the number is a whole number" do
       expect(command.format_number(2.0)).to eq("2")
     end

--- a/spec/google_server_create_spec.rb
+++ b/spec/google_server_create_spec.rb
@@ -33,7 +33,7 @@ describe Chef::Knife::Cloud::GoogleServerCreate do
 
   it_behaves_like Chef::Knife::Cloud::Command, described_class.new
 
-  describe '#validate_params!' do
+  describe "#validate_params!" do
     before do
       allow(command).to receive(:check_for_missing_config_values!)
       allow(command).to receive(:valid_disk_size?).and_return(true)
@@ -87,7 +87,7 @@ describe Chef::Knife::Cloud::GoogleServerCreate do
     end
   end
 
-  describe '#before_bootstrap' do
+  describe "#before_bootstrap" do
     before do
       allow(command).to receive(:ip_address_for_bootstrap)
       allow(command).to receive(:locate_config_value)
@@ -125,41 +125,41 @@ describe Chef::Knife::Cloud::GoogleServerCreate do
     end
   end
 
-  describe '#get_node_name' do
+  describe "#get_node_name" do
     it "overrides the original method to return nil" do
       expect(command.get_node_name("name", "prefix")).to eq(nil)
     end
   end
 
-  describe '#project' do
+  describe "#project" do
     it "returns the project from the config" do
       expect(command).to receive(:locate_config_value).with(:gce_project).and_return("test_project")
       expect(command.project).to eq("test_project")
     end
   end
 
-  describe '#zone' do
+  describe "#zone" do
     it "returns the zone from the config" do
       expect(command).to receive(:locate_config_value).with(:gce_zone).and_return("test_zone")
       expect(command.zone).to eq("test_zone")
     end
   end
 
-  describe '#email' do
+  describe "#email" do
     it "returns the email from the config" do
       expect(command).to receive(:locate_config_value).with(:gce_email).and_return("test_email")
       expect(command.email).to eq("test_email")
     end
   end
 
-  describe '#preemptible?' do
+  describe "#preemptible?" do
     it "returns the preemptible setting from the config" do
       expect(command).to receive(:locate_config_value).with(:preemptible).and_return("test_preempt")
       expect(command.preemptible?).to eq("test_preempt")
     end
   end
 
-  describe '#auto_migrate?' do
+  describe "#auto_migrate?" do
     it "returns false if the instance is preemptible" do
       expect(command).to receive(:preemptible?).and_return(true)
       expect(command.auto_migrate?).to eq(false)
@@ -172,7 +172,7 @@ describe Chef::Knife::Cloud::GoogleServerCreate do
     end
   end
 
-  describe '#auto_restart?' do
+  describe "#auto_restart?" do
     it "returns false if the instance is preemptible" do
       expect(command).to receive(:preemptible?).and_return(true)
       expect(command.auto_restart?).to eq(false)
@@ -185,7 +185,7 @@ describe Chef::Knife::Cloud::GoogleServerCreate do
     end
   end
 
-  describe '#ip_address_for_bootstrap' do
+  describe "#ip_address_for_bootstrap" do
     it "returns the public IP by default" do
       expect(command).to receive(:locate_config_value).with(:use_private_ip).and_return(false)
       expect(command).to receive(:public_ip_for).and_return("1.2.3.4")
@@ -205,21 +205,21 @@ describe Chef::Knife::Cloud::GoogleServerCreate do
     end
   end
 
-  describe '#metadata' do
+  describe "#metadata" do
     it "returns a hash of metadata" do
       expect(command).to receive(:locate_config_value).with(:metadata).and_return(["key1=value1", "key2=value2"])
       expect(command.metadata).to eq({ "key1" => "value1", "key2" => "value2" })
     end
   end
 
-  describe '#boot_disk_size' do
+  describe "#boot_disk_size" do
     it "returns the disk size as an integer" do
       expect(command).to receive(:locate_config_value).with(:boot_disk_size).and_return("20")
       expect(command.boot_disk_size).to eq(20)
     end
   end
 
-  describe '#reset_windows_password' do
+  describe "#reset_windows_password" do
     it "returns the password from the gcewinpass instance" do
       winpass = double("winpass", new_password: "my_password")
       expect(GoogleComputeWindowsPassword).to receive(:new).and_return(winpass)

--- a/spec/google_server_delete_spec.rb
+++ b/spec/google_server_delete_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Knife::Cloud::GoogleServerDelete do
 
   it_behaves_like Chef::Knife::Cloud::ServerDeleteCommand, described_class.new(["test_instance"])
 
-  describe '#validate_params!' do
+  describe "#validate_params!" do
     it "checks for missing config values" do
       expect(command).to receive(:check_for_missing_config_values!)
       command.validate_params!

--- a/spec/google_server_list_spec.rb
+++ b/spec/google_server_list_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Knife::Cloud::GoogleServerList do
 
   it_behaves_like Chef::Knife::Cloud::Command, described_class.new
 
-  describe '#validate_params!' do
+  describe "#validate_params!" do
     it "checks for missing config values" do
       expect(command).to receive(:check_for_missing_config_values!)
 
@@ -38,7 +38,7 @@ describe Chef::Knife::Cloud::GoogleServerList do
     end
   end
 
-  describe '#format_status_value' do
+  describe "#format_status_value" do
     it "returns green when the status is ready" do
       expect(command.ui).to receive(:color).with("ready", :green)
       command.format_status_value("ready")

--- a/spec/google_server_show_spec.rb
+++ b/spec/google_server_show_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Knife::Cloud::GoogleServerShow do
 
   it_behaves_like Chef::Knife::Cloud::Command, described_class.new
 
-  describe '#validate_params!' do
+  describe "#validate_params!" do
     before do
       allow(command).to receive(:check_for_missing_config_values!)
     end

--- a/spec/google_zone_list_spec.rb
+++ b/spec/google_zone_list_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Knife::Cloud::GoogleZoneList do
 
   it_behaves_like Chef::Knife::Cloud::Command, described_class.new
 
-  describe '#validate_params!' do
+  describe "#validate_params!" do
     it "checks for missing config values" do
       expect(command).to receive(:check_for_missing_config_values!)
 
@@ -38,14 +38,14 @@ describe Chef::Knife::Cloud::GoogleZoneList do
     end
   end
 
-  describe '#query_resource' do
+  describe "#query_resource" do
     it "uses the service to list zones" do
       expect(service).to receive(:list_zones).and_return("zones")
       expect(command.query_resource).to eq("zones")
     end
   end
 
-  describe '#format_status_value' do
+  describe "#format_status_value" do
     it "returns green when the status is up" do
       expect(command.ui).to receive(:color).with("up", :green)
       command.format_status_value("up")


### PR DESCRIPTION
This PR does a minor version bump to v2.2.1 to incorporate #109, updates the CHANGELOG, and update Travis to drop support for Ruby 2.0 and add ruby-head ([latest version](http://rubies.travis-ci.org/)).