### PR TITLE
Allow installation on ChefDK 2.0

### DIFF
--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/chef/knife-google"
   s.required_ruby_version = ">= 2.2.2"
 
-  s.add_dependency "chef",              "~> 12.0"
+  s.add_dependency "chef",              ">= 12.0"
   s.add_dependency "knife-cloud",       "~> 1.2.0"
   s.add_dependency "google-api-client", "~> 0.9.0"
   s.add_dependency "gcewinpass",        "~> 1.0"


### PR DESCRIPTION
Add a dep on Chef >= 12 not ~12. Obvious fix. No DCO required