### PR TITLE
remove chef as a direct dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,11 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake"
-gem "rspec",     "~> 3.1"
-gem "simplecov", "~> 0.9"
-gem "pry"
-gem "chefstyle"
+group :development do
+  gem "chef",      ">= 12.0"
+  gem "rake"
+  gem "rspec",     "~> 3.1"
+  gem "simplecov", "~> 0.9"
+  gem "pry"
+  gem "chefstyle"
+end

--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/chef/knife-google"
   s.required_ruby_version = ">= 2.2.2"
 
-  s.add_dependency "chef",              ">= 12.0"
   s.add_dependency "knife-cloud",       "~> 1.2.0"
   s.add_dependency "google-api-client", "~> 0.9.0"
   s.add_dependency "gcewinpass",        "~> 1.0"


### PR DESCRIPTION
knife plugins should have chef only as a dev dep

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>