### PR TITLE
Upgrade google-api-client version to 0.19.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-gem "rb-readline"
-
 gemspec
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
+gem "rb-readline"
+
 gemspec
 
 group :development do

--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.2"
 
   s.add_dependency "knife-cloud",       "~> 1.2.0"
-  s.add_dependency "google-api-client", "~> 0.9.0"
-  s.add_dependency "gcewinpass",        "~> 1.0"
+  s.add_dependency "google-api-client", "~> 0.19.8"
+  s.add_dependency "gcewinpass",        "~> 1.1"
 
   s.add_development_dependency "github_changelog_generator"
 

--- a/lib/knife-google/version.rb
+++ b/lib/knife-google/version.rb
@@ -15,7 +15,7 @@
 #
 module Knife
   module Google
-    VERSION = "3.2.0"
+    VERSION = "3.2.1"
     MAJOR, MINOR, TINY = VERSION.split(".")
   end
 end


### PR DESCRIPTION
Description
Upgrade google-api-client to 0.19.8 and done testing with all knife google commands.

Issues Resolved
MSYS-862

Signed-off-by: NAshwini <ashwini.nehate@msystechnologies.com>