### PR TITLE
Allow for newer google-api-client releases

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -17,6 +17,9 @@ github:
   minor_bump_labels:
     - "Expeditor: Bump Minor Version"
 
+changelog:
+  rollup_header: Changes not yet released to rubygems.org
+
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:
   - built_in:bump_version:

--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.2"
 
   s.add_dependency "knife-cloud",       "~> 1.2.0"
-  s.add_dependency "google-api-client", "~> 0.19.8"
+  s.add_dependency "google-api-client", ">= 0.19.8", "< 0.25" # each version introduces breaking changes which we need to validate
   s.add_dependency "gcewinpass",        "~> 1.1"
 
   s.add_development_dependency "github_changelog_generator"


### PR DESCRIPTION
They're breaking on each release since they're not at 1.0 so let's allow
0.19 - 0.24. We need this bump so we can bring in the new train in DK.

Signed-off-by: Tim Smith <tsmith@chef.io>