### PR TITLE
Remove github_changelog_generator development dependency

### DIFF
--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -21,7 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency "google-api-client", ">= 0.19.8", "< 0.25" # each version introduces breaking changes which we need to validate
   s.add_dependency "gcewinpass",        "~> 1.1"
 
-  s.add_development_dependency "github_changelog_generator"
-
   s.files = `git ls-files -z`.split("\x0")
 end


### PR DESCRIPTION
We're not using this anymore

Signed-off-by: Tim Smith <tsmith@chef.io>