### PR TITLE
Update minimum google-api-client version.

### DIFF
--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.2"
 
   s.add_dependency "knife-cloud",       "~> 1.2.0"
-  s.add_dependency "google-api-client", ">= 0.19.8", "< 0.25" # each version introduces breaking changes which we need to validate
+  s.add_dependency "google-api-client", "~> 0.23.9", "< 0.25" # each version introduces breaking changes which we need to validate
   s.add_dependency "gcewinpass",        "~> 1.1"
 
   s.files = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
Update the minimum google-api-client version to match what we ship with train, so we can ship a new check =)

I ran the tests and they were fine, let me know if there is anything I missed.