### PR TITLE
Update google-api-client version to 0.23.9

### DIFF
--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.2.2"
 
   s.add_dependency "knife-cloud",       "~> 1.2.0"
-  s.add_dependency "google-api-client", ">= 0.19.8", "< 0.25" # each version introduces breaking changes which we need to validate
+  s.add_dependency "google-api-client", "~> 0.23.9"
   s.add_dependency "gcewinpass",        "~> 1.1"
 
   s.files = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description
Bump the version of google-api-client to match with other google-api-client versions in ChefDK. 

### Issues Resolved
Fixes MSYS-911

Tested the changes with all knife google commands.

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
