### PR TITLE
MSYS-917 Allows knife google zone list, region list, region quotas, project quotas to run without giving --gce_zone option

### DIFF
--- a/lib/chef/knife/cloud/google_service_helpers.rb
+++ b/lib/chef/knife/cloud/google_service_helpers.rb
@@ -19,7 +19,7 @@
 
 class Chef::Knife::Cloud
   module GoogleServiceHelpers
-    REQUIRED_KEYS = [:gce_project, :gce_zone].freeze
+    REQUIRED_KEYS = [:gce_project].freeze
 
     def create_service_instance
       Chef::Knife::Cloud::GoogleService.new(

--- a/lib/chef/knife/google_disk_create.rb
+++ b/lib/chef/knife/google_disk_create.rb
@@ -47,7 +47,7 @@ class Chef::Knife::Cloud
       default:     nil
 
     def validate_params!
-      check_for_missing_config_values!(:disk_size, :disk_type)
+      check_for_missing_config_values!(:gce_zone, :disk_size, :disk_type)
       raise "Please specify a disk name." unless @name_args.first
       raise "Disk size must be between 10 and 10,000" unless valid_disk_size?(locate_config_value(:disk_size))
       super

--- a/lib/chef/knife/google_disk_delete.rb
+++ b/lib/chef/knife/google_disk_delete.rb
@@ -31,7 +31,7 @@ class Chef::Knife::Cloud
     banner "knife google disk delete NAME [NAME] (options)"
 
     def validate_params!
-      check_for_missing_config_values!
+      check_for_missing_config_values!(:gce_zone)
       raise "You must specify at least one disk to delete." if @name_args.empty?
       super
     end

--- a/lib/chef/knife/google_disk_list.rb
+++ b/lib/chef/knife/google_disk_list.rb
@@ -31,7 +31,7 @@ class Chef::Knife::Cloud
     banner "knife google disk list"
 
     def validate_params!
-      check_for_missing_config_values!
+      check_for_missing_config_values!(:gce_zone)
       super
     end
 

--- a/lib/chef/knife/google_server_create.rb
+++ b/lib/chef/knife/google_server_create.rb
@@ -184,7 +184,7 @@ class Chef::Knife::Cloud
     end
 
     def validate_params!
-      check_for_missing_config_values!(:machine_type, :image, :boot_disk_size, :network)
+      check_for_missing_config_values!(:gce_zone, :machine_type, :image, :boot_disk_size, :network)
       raise "You must supply an instance name." if @name_args.first.nil?
       raise "Boot disk size must be between 10 and 10,000" unless valid_disk_size?(boot_disk_size)
       if locate_config_value(:bootstrap_protocol) == "winrm" && locate_config_value(:gce_email).nil?

--- a/lib/chef/knife/google_server_list.rb
+++ b/lib/chef/knife/google_server_list.rb
@@ -32,7 +32,7 @@ class Chef::Knife::Cloud
     banner "knife google server list"
 
     def validate_params!
-      check_for_missing_config_values!
+      check_for_missing_config_values!(:gce_zone)
       super
     end
 

--- a/lib/chef/knife/google_server_show.rb
+++ b/lib/chef/knife/google_server_show.rb
@@ -34,7 +34,7 @@ class Chef
         banner "knife google server show INSTANCE_NAME (options)"
 
         def validate_params!
-          check_for_missing_config_values!
+          check_for_missing_config_values!(:gce_zone)
           raise "You must supply an instance name to display" if @name_args.empty?
           raise "You may only supply one instance name" if @name_args.size > 1
           super

--- a/spec/cloud/google_service_helpers_spec.rb
+++ b/spec/cloud/google_service_helpers_spec.rb
@@ -52,7 +52,6 @@ describe Chef::Knife::Cloud::GoogleServiceHelpers do
   describe "#check_for_missing_config_values" do
     it "does not raise an exception if all parameters are present" do
       expect(tester).to receive(:locate_config_value).with(:gce_project).and_return("project")
-      expect(tester).to receive(:locate_config_value).with(:gce_zone).and_return("zone")
       expect(tester).to receive(:locate_config_value).with(:key1).and_return("value1")
       expect(tester).to receive(:locate_config_value).with(:key2).and_return("value2")
 
@@ -63,10 +62,9 @@ describe Chef::Knife::Cloud::GoogleServiceHelpers do
       ui = double("ui")
       expect(tester).to receive(:ui).and_return(ui)
       expect(tester).to receive(:locate_config_value).with(:gce_project).and_return("project")
-      expect(tester).to receive(:locate_config_value).with(:gce_zone).and_return(nil)
       expect(tester).to receive(:locate_config_value).with(:key1).and_return("value1")
       expect(tester).to receive(:locate_config_value).with(:key2).and_return(nil)
-      expect(ui).to receive(:error).with("The following required parameters are missing: gce_zone, key2")
+      expect(ui).to receive(:error).with("The following required parameters are missing: key2")
       expect { tester.check_for_missing_config_values!(:key1, :key2) }.to raise_error(RuntimeError)
     end
   end

--- a/spec/google_disk_create_spec.rb
+++ b/spec/google_disk_create_spec.rb
@@ -21,7 +21,12 @@ require "spec_helper"
 require "chef/knife/google_disk_create"
 require "support/shared_examples_for_command"
 
+class Tester
+  include Chef::Knife::Cloud::GoogleServiceHelpers
+end
+
 describe Chef::Knife::Cloud::GoogleDiskCreate do
+  let(:tester) { Tester.new }
   let(:command) { described_class.new(%w{disk1}) }
   let(:service) { double("service") }
 
@@ -38,7 +43,7 @@ describe Chef::Knife::Cloud::GoogleDiskCreate do
     end
 
     it "checks for missing config values" do
-      expect(command).to receive(:check_for_missing_config_values!).with(:disk_size, :disk_type)
+      expect(command).to receive(:check_for_missing_config_values!).with(:gce_zone, :disk_size, :disk_type)
 
       command.validate_params!
     end
@@ -50,6 +55,14 @@ describe Chef::Knife::Cloud::GoogleDiskCreate do
     it "raises an exception if the disk size is invalid" do
       expect(command).to receive(:valid_disk_size?).and_return(false)
       expect { command.validate_params! }.to raise_error(RuntimeError, "Disk size must be between 10 and 10,000")
+    end
+
+    it "raises an exception if the gce_project is missing" do
+      ui = double("ui")
+      expect(tester).to receive(:ui).and_return(ui)
+      expect(tester).to receive(:locate_config_value).with(:gce_project).and_return(nil)
+      expect(ui).to receive(:error).with("The following required parameters are missing: gce_project")
+      expect { tester.check_for_missing_config_values! }.to raise_error(RuntimeError)
     end
 
     context "when no disk name is provided" do

--- a/spec/google_disk_list_spec.rb
+++ b/spec/google_disk_list_spec.rb
@@ -21,7 +21,12 @@ require "spec_helper"
 require "chef/knife/google_disk_list"
 require "support/shared_examples_for_command"
 
+class Tester
+  include Chef::Knife::Cloud::GoogleServiceHelpers
+end
+
 describe Chef::Knife::Cloud::GoogleDiskList do
+  let(:tester) { Tester.new }
   let(:command) { described_class.new }
   let(:service) { double("service") }
 
@@ -33,9 +38,17 @@ describe Chef::Knife::Cloud::GoogleDiskList do
 
   describe "#validate_params!" do
     it "checks for missing config values" do
-      expect(command).to receive(:check_for_missing_config_values!)
+      expect(command).to receive(:check_for_missing_config_values!).with(:gce_zone)
 
       command.validate_params!
+    end
+
+    it "raises an exception if the gce_project is missing" do
+      ui = double("ui")
+      expect(tester).to receive(:ui).and_return(ui)
+      expect(tester).to receive(:locate_config_value).with(:gce_project).and_return(nil)
+      expect(ui).to receive(:error).with("The following required parameters are missing: gce_project")
+      expect { tester.check_for_missing_config_values! }.to raise_error(RuntimeError)
     end
   end
 

--- a/spec/google_project_quotas_spec.rb
+++ b/spec/google_project_quotas_spec.rb
@@ -21,7 +21,12 @@ require "spec_helper"
 require "chef/knife/google_project_quotas"
 require "support/shared_examples_for_command"
 
+class Tester
+  include Chef::Knife::Cloud::GoogleServiceHelpers
+end
+
 describe Chef::Knife::Cloud::GoogleProjectQuotas do
+  let(:tester) { Tester.new }
   let(:command) { described_class.new }
   let(:service) { double("service") }
 
@@ -36,6 +41,14 @@ describe Chef::Knife::Cloud::GoogleProjectQuotas do
       expect(command).to receive(:check_for_missing_config_values!)
 
       command.validate_params!
+    end
+
+    it "raises an exception if the gce_project is missing" do
+      ui = double("ui")
+      expect(tester).to receive(:ui).and_return(ui)
+      expect(tester).to receive(:locate_config_value).with(:gce_project).and_return(nil)
+      expect(ui).to receive(:error).with("The following required parameters are missing: gce_project")
+      expect { tester.check_for_missing_config_values! }.to raise_error(RuntimeError)
     end
   end
 

--- a/spec/google_region_list_spec.rb
+++ b/spec/google_region_list_spec.rb
@@ -21,7 +21,12 @@ require "spec_helper"
 require "chef/knife/google_region_list"
 require "support/shared_examples_for_command"
 
+class Tester
+  include Chef::Knife::Cloud::GoogleServiceHelpers
+end
+
 describe Chef::Knife::Cloud::GoogleRegionList do
+  let(:tester) { Tester.new }
   let(:command) { described_class.new }
   let(:service) { double("service") }
 
@@ -36,6 +41,14 @@ describe Chef::Knife::Cloud::GoogleRegionList do
       expect(command).to receive(:check_for_missing_config_values!)
 
       command.validate_params!
+    end
+
+    it "raises an exception if the gce_project is missing" do
+      ui = double("ui")
+      expect(tester).to receive(:ui).and_return(ui)
+      expect(tester).to receive(:locate_config_value).with(:gce_project).and_return(nil)
+      expect(ui).to receive(:error).with("The following required parameters are missing: gce_project")
+      expect { tester.check_for_missing_config_values! }.to raise_error(RuntimeError)
     end
   end
 

--- a/spec/google_region_quotas_spec.rb
+++ b/spec/google_region_quotas_spec.rb
@@ -21,7 +21,12 @@ require "spec_helper"
 require "chef/knife/google_region_quotas"
 require "support/shared_examples_for_command"
 
+class Tester
+  include Chef::Knife::Cloud::GoogleServiceHelpers
+end
+
 describe Chef::Knife::Cloud::GoogleRegionQuotas do
+  let(:tester) { Tester.new }
   let(:command) { described_class.new }
   let(:service) { double("service") }
 
@@ -36,6 +41,14 @@ describe Chef::Knife::Cloud::GoogleRegionQuotas do
       expect(command).to receive(:check_for_missing_config_values!)
 
       command.validate_params!
+    end
+
+    it "raises an exception if the gce_project is missing" do
+      ui = double("ui")
+      expect(tester).to receive(:ui).and_return(ui)
+      expect(tester).to receive(:locate_config_value).with(:gce_project).and_return(nil)
+      expect(ui).to receive(:error).with("The following required parameters are missing: gce_project")
+      expect { tester.check_for_missing_config_values! }.to raise_error(RuntimeError)
     end
   end
 

--- a/spec/google_server_delete_spec.rb
+++ b/spec/google_server_delete_spec.rb
@@ -21,7 +21,12 @@ require "spec_helper"
 require "chef/knife/google_server_delete"
 require "support/shared_examples_for_serverdeletecommand"
 
+class Tester
+  include Chef::Knife::Cloud::GoogleServiceHelpers
+end
+
 describe Chef::Knife::Cloud::GoogleServerDelete do
+  let(:tester) { Tester.new }
   let(:command) { described_class.new(["test_instance"]) }
   let(:service) { double("service") }
 
@@ -35,6 +40,14 @@ describe Chef::Knife::Cloud::GoogleServerDelete do
     it "checks for missing config values" do
       expect(command).to receive(:check_for_missing_config_values!)
       command.validate_params!
+    end
+
+    it "raises an exception if the gce_project is missing" do
+      ui = double("ui")
+      expect(tester).to receive(:ui).and_return(ui)
+      expect(tester).to receive(:locate_config_value).with(:gce_project).and_return(nil)
+      expect(ui).to receive(:error).with("The following required parameters are missing: gce_project")
+      expect { tester.check_for_missing_config_values! }.to raise_error(RuntimeError)
     end
   end
 end

--- a/spec/google_server_list_spec.rb
+++ b/spec/google_server_list_spec.rb
@@ -21,7 +21,12 @@ require "spec_helper"
 require "chef/knife/google_server_list"
 require "support/shared_examples_for_command"
 
+class Tester
+  include Chef::Knife::Cloud::GoogleServiceHelpers
+end
+
 describe Chef::Knife::Cloud::GoogleServerList do
+  let(:tester) { Tester.new }
   let(:command) { described_class.new }
   let(:service) { double("service") }
 
@@ -33,9 +38,17 @@ describe Chef::Knife::Cloud::GoogleServerList do
 
   describe "#validate_params!" do
     it "checks for missing config values" do
-      expect(command).to receive(:check_for_missing_config_values!)
+      expect(command).to receive(:check_for_missing_config_values!).with(:gce_zone)
 
       command.validate_params!
+    end
+
+    it "raises an exception if the gce_project is missing" do
+      ui = double("ui")
+      expect(tester).to receive(:ui).and_return(ui)
+      expect(tester).to receive(:locate_config_value).with(:gce_project).and_return(nil)
+      expect(ui).to receive(:error).with("The following required parameters are missing: gce_project")
+      expect { tester.check_for_missing_config_values! }.to raise_error(RuntimeError)
     end
   end
 

--- a/spec/google_server_show_spec.rb
+++ b/spec/google_server_show_spec.rb
@@ -21,7 +21,12 @@ require "spec_helper"
 require "chef/knife/google_server_show"
 require "support/shared_examples_for_command"
 
+class Tester
+  include Chef::Knife::Cloud::GoogleServiceHelpers
+end
+
 describe Chef::Knife::Cloud::GoogleServerShow do
+  let(:tester) { Tester.new }
   let(:command) { described_class.new(["test_instance"]) }
   let(:service) { double("service") }
 
@@ -37,9 +42,17 @@ describe Chef::Knife::Cloud::GoogleServerShow do
     end
 
     it "checks for missing config values" do
-      expect(command).to receive(:check_for_missing_config_values!)
+      expect(command).to receive(:check_for_missing_config_values!).with(:gce_zone)
 
       command.validate_params!
+    end
+
+    it "raises an exception if the gce_project is missing" do
+      ui = double("ui")
+      expect(tester).to receive(:ui).and_return(ui)
+      expect(tester).to receive(:locate_config_value).with(:gce_project).and_return(nil)
+      expect(ui).to receive(:error).with("The following required parameters are missing: gce_project")
+      expect { tester.check_for_missing_config_values! }.to raise_error(RuntimeError)
     end
 
     context "when no server name is provided" do

--- a/spec/google_zone_list_spec.rb
+++ b/spec/google_zone_list_spec.rb
@@ -21,7 +21,12 @@ require "spec_helper"
 require "chef/knife/google_zone_list"
 require "support/shared_examples_for_command"
 
+class Tester
+  include Chef::Knife::Cloud::GoogleServiceHelpers
+end
+
 describe Chef::Knife::Cloud::GoogleZoneList do
+  let(:tester) { Tester.new }
   let(:command) { described_class.new }
   let(:service) { double("service") }
 
@@ -36,6 +41,14 @@ describe Chef::Knife::Cloud::GoogleZoneList do
       expect(command).to receive(:check_for_missing_config_values!)
 
       command.validate_params!
+    end
+
+    it "raises an exception if the gce_project is missing" do
+      ui = double("ui")
+      expect(tester).to receive(:ui).and_return(ui)
+      expect(tester).to receive(:locate_config_value).with(:gce_project).and_return(nil)
+      expect(ui).to receive(:error).with("The following required parameters are missing: gce_project")
+      expect { tester.check_for_missing_config_values! }.to raise_error(RuntimeError)
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Vasu1105 <vasundhara.jagdale@msystechnologies.com>

### Description
knife google zone list, region list, region quotas, project quotas do not require --gce_zone to be provided. Removed zone validation for all these commands.
### Issues Resolved
#129 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
