### PR TITLE
Add new command knife google image list

### DIFF
--- a/lib/chef/knife/cloud/google_service.rb
+++ b/lib/chef/knife/cloud/google_service.rb
@@ -78,6 +78,20 @@ class Chef::Knife::Cloud
       "windows-2012-r2" => { project: "windows-cloud", prefix: "windows-server-2012-r2" },
     }.freeze
 
+    PUBLIC_PROJECTS = %w{
+      centos-cloud
+      coreos-cloud
+      debian-cloud
+      cos-cloud
+      rhel-cloud
+      rhel-sap-cloud
+      suse-cloud
+      suse-sap-cloud
+      ubuntu-os-cloud
+      windows-cloud
+      windows-sql-cloud
+    }.freeze
+
     def initialize(options = {})
       @project       = options[:project]
       @zone          = options[:zone]
@@ -195,6 +209,12 @@ class Chef::Knife::Cloud
 
     def list_zones
       paginated_results(:list_zones, :items, project) || []
+    end
+
+    # Retrieves the list of custom images and public images.
+    # Custom images are images you create that belong to your project.
+    def list_images
+      available_projects.map { |project| paginated_results(:list_images, :items, project) || [] }.flatten
     end
 
     def list_disks
@@ -602,6 +622,10 @@ class Chef::Knife::Cloud
       return [] if operation.error.nil?
 
       operation.error.errors
+    end
+
+    def available_projects
+      [project] | PUBLIC_PROJECTS
     end
   end
 end

--- a/lib/chef/knife/cloud/google_service_helpers.rb
+++ b/lib/chef/knife/cloud/google_service_helpers.rb
@@ -27,8 +27,8 @@ class Chef::Knife::Cloud
         zone:          locate_config_value(:gce_zone),
         wait_time:     locate_config_value(:request_timeout),
         refresh_rate:  locate_config_value(:request_refresh_rate),
-        max_pages:     locate_config_value(:max_pages),
-        max_page_size: locate_config_value(:max_page_size)
+        max_pages:     locate_config_value(:gce_max_pages),
+        max_page_size: locate_config_value(:gce_max_page_size)
       )
     end
 

--- a/lib/chef/knife/google_image_list.rb
+++ b/lib/chef/knife/google_image_list.rb
@@ -1,0 +1,59 @@
+#
+# Author:: Kapil Chouhan (<kapil.chouhan@msystechnologies.com>)
+# Copyright:: Copyright (c) 2018-2019 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "chef/knife"
+require "chef/knife/cloud/list_resource_command"
+require "chef/knife/cloud/google_service"
+require "chef/knife/cloud/google_service_helpers"
+require "chef/knife/cloud/google_service_options"
+
+class Chef::Knife::Cloud
+  class GoogleImageList < ResourceListCommand
+    include GoogleServiceHelpers
+    include GoogleServiceOptions
+
+    banner "knife google image list"
+
+    def validate_params!
+      check_for_missing_config_values!
+      super
+    end
+
+    def before_exec_command
+      @columns_with_info = [
+        { label: "NAME", key: "name" },
+        { label: "PROJECT", key: "self_link", value_callback: method(:find_project_name) },
+        { label: "FAMILY", key: "family" },
+        { label: "DISK SIZE", key: "disk_size_gb", value_callback: method(:format_disk_size_value) },
+        { label: "STATUS", key: "status" },
+      ]
+    end
+
+    def find_project_name(self_link)
+      self_link[%r{projects\/(.*?)\/}m, 1]
+    end
+
+    def format_disk_size_value(disk_size)
+      "#{disk_size} GB"
+    end
+
+    def query_resource
+      service.list_images
+    end
+  end
+end

--- a/spec/cloud/google_service_helpers_spec.rb
+++ b/spec/cloud/google_service_helpers_spec.rb
@@ -33,8 +33,8 @@ describe Chef::Knife::Cloud::GoogleServiceHelpers do
       expect(tester).to receive(:locate_config_value).with(:gce_zone).and_return("test_zone")
       expect(tester).to receive(:locate_config_value).with(:request_timeout).and_return(123)
       expect(tester).to receive(:locate_config_value).with(:request_refresh_rate).and_return(321)
-      expect(tester).to receive(:locate_config_value).with(:max_pages).and_return(456)
-      expect(tester).to receive(:locate_config_value).with(:max_page_size).and_return(654)
+      expect(tester).to receive(:locate_config_value).with(:gce_max_pages).and_return(456)
+      expect(tester).to receive(:locate_config_value).with(:gce_max_page_size).and_return(654)
 
       expect(Chef::Knife::Cloud::GoogleService).to receive(:new).with(
         project:       "test_project",

--- a/spec/google_image_list_spec.rb
+++ b/spec/google_image_list_spec.rb
@@ -1,0 +1,76 @@
+#
+# Author:: Kapil Chouhan (<kapil.chouhan@msystechnologies.com>)
+# Copyright:: Copyright (c) 2018-2019 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "chef/knife/google_image_list"
+require "support/shared_examples_for_command"
+
+class Tester
+  include Chef::Knife::Cloud::GoogleServiceHelpers
+end
+
+describe Chef::Knife::Cloud::GoogleImageList do
+  let(:tester) { Tester.new }
+  let(:command) { described_class.new }
+  let(:service) { double("service") }
+
+  before do
+    allow(command).to receive(:service).and_return(service)
+  end
+
+  it_behaves_like Chef::Knife::Cloud::Command, described_class.new
+
+  describe "#validate_params!" do
+    it "checks for missing config values" do
+      expect(command).to receive(:check_for_missing_config_values!)
+
+      command.validate_params!
+    end
+
+    it "raises an exception if the gce_project is missing" do
+      ui = double("ui")
+      expect(tester).to receive(:ui).and_return(ui)
+      expect(tester).to receive(:locate_config_value).with(:gce_project).and_return(nil)
+      expect(ui).to receive(:error).with("The following required parameters are missing: gce_project")
+      expect { tester.check_for_missing_config_values! }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe "#query_resource" do
+    it "uses the service to list images" do
+      expect(service).to receive(:list_images).and_return("images")
+      expect(command.query_resource).to eq("images")
+    end
+  end
+
+  describe "#find_project_name" do
+    let(:self_link) { "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-6-v20190916" }
+
+    it "returns project name" do
+      expect(command.find_project_name(self_link)).to eq("centos-cloud")
+    end
+  end
+
+  describe "#format_disk_size_value" do
+    let(:disk_size) { 32 }
+
+    it "returns project name" do
+      expect(command.format_disk_size_value(disk_size)).to eq("32 GB")
+    end
+  end
+end


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description
- Added new command `knife google image list`, which will be return list of images(custom images + public images)
  - Working command: `knife google image list --gce_project "chef-msys"`
  - Output:
  ```
   NAME                             PROJECT        FAMILY         DISK SIZE  STATUS
   kpl-w-image                      chef-msys      windows        60 GB      READY 
   centos-6-v20190916               centos-cloud   centos-6       10 GB      READY 
   centos-7-v20190916               centos-cloud   centos-7       10 GB      READY 
   coreos-alpha-2261-0-0-v20190911  coreos-cloud   coreos-alpha   9 GB       READY 
   coreos-beta-2247-2-0-v20190911   coreos-cloud   coreos-beta    9 GB       READY 
   ....
   ....
   ....
  ```

- Added test cases
- Ensured chef-style on the code changes made
- Refer to this doc [Images list](https://cloud.google.com/compute/docs/reference/rest/v1/images/list)

### Issues Resolved
Fixes: #97 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG