### PR TITLE
Fix for support multiple --local-ssd interfaces

### DIFF
--- a/lib/chef/knife/google_server_create.rb
+++ b/lib/chef/knife/google_server_create.rb
@@ -146,6 +146,23 @@ class Chef::Knife::Cloud
       long:        "--gce-email EMAIL_ADDRESS",
       description: "email address of the logged-in Google Cloud user; required for bootstrapping windows hosts"
 
+    option :local_ssd,
+      long:        "--gce-local-ssd",
+      description: "Local SSDs are physically attached to the server that hosts your VM instance. Local SSDs have higher throughput and lower latency than standard persistent disks or SSD persistent disks.",
+      boolean:     true,
+      default:     false
+
+    option :interface,
+      long: "--gce-interface INTERFACE",
+      description: "The kind of disk interface exposed to the VM for this SSD. Valid values are SCSI and NVME. SCSI is the default and is supported by more guest operating systems. NVME may provide higher performance.",
+      default: "scsi",
+      in: %w{scsi nvme}
+
+    option :number_of_local_ssd,
+      long: "--gce-number-of-local-ssd NUMBER_OF_DISKS",
+      description: "Specifies the number of local SSDs to be created per node. Each local SSD is 375 GB in size, but you can attach up to eight local SSD devices for 3 TB of total local SSD storage space per instance.",
+      default: "1"
+
     deps do
       require "gcewinpass"
     end
@@ -168,6 +185,9 @@ class Chef::Knife::Cloud
         boot_disk_size: boot_disk_size,
         boot_disk_ssd: locate_config_value(:boot_disk_ssd),
         additional_disks: locate_config_value(:additional_disks),
+        local_ssd: locate_config_value(:local_ssd),
+        interface: locate_config_value(:interface),
+        number_of_local_ssd: number_of_local_ssd,
         can_ip_forward: locate_config_value(:can_ip_forward),
         machine_type: locate_config_value(:machine_type),
         service_account_scopes: locate_config_value(:service_account_scopes),
@@ -269,6 +289,10 @@ class Chef::Knife::Cloud
 
     def boot_disk_size
       locate_config_value(:boot_disk_size).to_i
+    end
+
+    def number_of_local_ssd
+      locate_config_value(:number_of_local_ssd).to_i
     end
 
     def reset_windows_password

--- a/spec/google_server_create_spec.rb
+++ b/spec/google_server_create_spec.rb
@@ -248,11 +248,39 @@ describe Chef::Knife::Cloud::GoogleServerCreate do
     end
   end
 
+  describe "#number_of_local_ssd" do
+    it "returns the number of local ssd as an integer" do
+      expect(command).to receive(:locate_config_value).with(:number_of_local_ssd).and_return("5")
+      expect(command.number_of_local_ssd).to eq(5)
+    end
+  end
+
   describe "#reset_windows_password" do
     it "returns the password from the gcewinpass instance" do
       winpass = double("winpass", new_password: "my_password")
       expect(GoogleComputeWindowsPassword).to receive(:new).and_return(winpass)
       expect(command.reset_windows_password).to eq("my_password")
+    end
+  end
+
+  describe "local_ssd option is passed on CLI" do
+    let(:google_server_create) { Chef::Knife::Cloud::GoogleServerCreate.new(["--gce-local-ssd"]) }
+    it "when a local_ssd is present" do
+      expect(google_server_create.config[:local_ssd]).to eq(true)
+    end
+  end
+
+  describe "interface option is passed on CLI" do
+    let(:google_server_create) { Chef::Knife::Cloud::GoogleServerCreate.new(["--gce-interface", "nvme"]) }
+    it "when a interface is present" do
+      expect(google_server_create.config[:interface]).to eq("nvme")
+    end
+  end
+
+  describe "number_of_local_ssd option is passed on CLI" do
+    let(:google_server_create) { Chef::Knife::Cloud::GoogleServerCreate.new(["--gce-number-of-local-ssd", "5"]) }
+    it "when a number_of_local_ssd is present" do
+      expect(google_server_create.config[:number_of_local_ssd]).to eq("5")
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Kapil Chouhan <kapil.chouhan@msystechnologies.com>

### Description
- Added a couple of methods in `google_service.rb` file
- Added three options `local_ssd`, `interface` and `number_of_local_ssd` in `google_server_create.rb` file.
  - Working command:
    ```knife google server create kpl-8 --gce-image centos-7-v20160219 --gce-machine-type n1-standard-1 --gce-public-ip ephemeral --ssh-identity-file /.ssh/id_rsa --gce_project "chef-msys" --gce_zone "us-east1-b" --connection-port 22 --connection-protocol ssh --image-os-type linux --connection-user msys --gce-local-ssd --gce-interface "nvme" --gce-number-of-local-ssd 3```
- Added test cases
- Ensured chef-style on the code changes made

### Issues Resolved
Fixes: #105 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG