### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/chef/knife/cloud/google_service.rb
+++ b/lib/chef/knife/cloud/google_service.rb
@@ -20,10 +20,10 @@
 require "chef/knife/cloud/exceptions"
 require "chef/knife/cloud/service"
 require "chef/knife/cloud/helpers"
-require "chef/knife/cloud/google_service_helpers"
+require_relative "google_service_helpers"
 require "google/apis/compute_v1"
 require "ipaddr"
-require "knife-google/version"
+require_relative "../../../knife-google/version"
 
 class Chef::Knife::Cloud
   class GoogleService < Service

--- a/lib/chef/knife/google_disk_create.rb
+++ b/lib/chef/knife/google_disk_create.rb
@@ -19,9 +19,9 @@
 
 require "chef/knife"
 require "chef/knife/cloud/command"
-require "chef/knife/cloud/google_service"
-require "chef/knife/cloud/google_service_helpers"
-require "chef/knife/cloud/google_service_options"
+require_relative "cloud/google_service"
+require_relative "cloud/google_service_helpers"
+require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
   class GoogleDiskCreate < Command

--- a/lib/chef/knife/google_disk_delete.rb
+++ b/lib/chef/knife/google_disk_delete.rb
@@ -19,9 +19,9 @@
 
 require "chef/knife"
 require "chef/knife/cloud/command"
-require "chef/knife/cloud/google_service"
-require "chef/knife/cloud/google_service_helpers"
-require "chef/knife/cloud/google_service_options"
+require_relative "cloud/google_service"
+require_relative "cloud/google_service_helpers"
+require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
   class GoogleDiskDelete < Command

--- a/lib/chef/knife/google_disk_list.rb
+++ b/lib/chef/knife/google_disk_list.rb
@@ -19,9 +19,9 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/cloud/google_service"
-require "chef/knife/cloud/google_service_helpers"
-require "chef/knife/cloud/google_service_options"
+require_relative "cloud/google_service"
+require_relative "cloud/google_service_helpers"
+require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
   class GoogleDiskList < ResourceListCommand

--- a/lib/chef/knife/google_image_list.rb
+++ b/lib/chef/knife/google_image_list.rb
@@ -18,9 +18,9 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/cloud/google_service"
-require "chef/knife/cloud/google_service_helpers"
-require "chef/knife/cloud/google_service_options"
+require_relative "cloud/google_service"
+require_relative "cloud/google_service_helpers"
+require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
   class GoogleImageList < ResourceListCommand

--- a/lib/chef/knife/google_project_quotas.rb
+++ b/lib/chef/knife/google_project_quotas.rb
@@ -19,9 +19,9 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/cloud/google_service"
-require "chef/knife/cloud/google_service_helpers"
-require "chef/knife/cloud/google_service_options"
+require_relative "cloud/google_service"
+require_relative "cloud/google_service_helpers"
+require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
   class GoogleProjectQuotas < ResourceListCommand

--- a/lib/chef/knife/google_region_list.rb
+++ b/lib/chef/knife/google_region_list.rb
@@ -19,9 +19,9 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/cloud/google_service"
-require "chef/knife/cloud/google_service_helpers"
-require "chef/knife/cloud/google_service_options"
+require_relative "cloud/google_service"
+require_relative "cloud/google_service_helpers"
+require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
   class GoogleRegionList < ResourceListCommand

--- a/lib/chef/knife/google_region_quotas.rb
+++ b/lib/chef/knife/google_region_quotas.rb
@@ -19,9 +19,9 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/cloud/google_service"
-require "chef/knife/cloud/google_service_helpers"
-require "chef/knife/cloud/google_service_options"
+require_relative "cloud/google_service"
+require_relative "cloud/google_service_helpers"
+require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
   class GoogleRegionQuotas < Command

--- a/lib/chef/knife/google_server_create.rb
+++ b/lib/chef/knife/google_server_create.rb
@@ -20,9 +20,9 @@
 require "chef/knife"
 require "chef/knife/cloud/server/create_command"
 require "chef/knife/cloud/server/create_options"
-require "chef/knife/cloud/google_service"
-require "chef/knife/cloud/google_service_helpers"
-require "chef/knife/cloud/google_service_options"
+require_relative "cloud/google_service"
+require_relative "cloud/google_service_helpers"
+require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
   class GoogleServerCreate < ServerCreateCommand

--- a/lib/chef/knife/google_server_delete.rb
+++ b/lib/chef/knife/google_server_delete.rb
@@ -20,9 +20,9 @@
 require "chef/knife"
 require "chef/knife/cloud/server/delete_options"
 require "chef/knife/cloud/server/delete_command"
-require "chef/knife/cloud/google_service"
-require "chef/knife/cloud/google_service_helpers"
-require "chef/knife/cloud/google_service_options"
+require_relative "cloud/google_service"
+require_relative "cloud/google_service_helpers"
+require_relative "cloud/google_service_options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/google_server_list.rb
+++ b/lib/chef/knife/google_server_list.rb
@@ -20,9 +20,9 @@
 require "chef/knife"
 require "chef/knife/cloud/server/list_command"
 require "chef/knife/cloud/server/list_options"
-require "chef/knife/cloud/google_service"
-require "chef/knife/cloud/google_service_helpers"
-require "chef/knife/cloud/google_service_options"
+require_relative "cloud/google_service"
+require_relative "cloud/google_service_helpers"
+require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
   class GoogleServerList < ServerListCommand

--- a/lib/chef/knife/google_server_show.rb
+++ b/lib/chef/knife/google_server_show.rb
@@ -19,9 +19,9 @@
 require "chef/knife"
 require "chef/knife/cloud/server/show_options"
 require "chef/knife/cloud/server/show_command"
-require "chef/knife/cloud/google_service"
-require "chef/knife/cloud/google_service_helpers"
-require "chef/knife/cloud/google_service_options"
+require_relative "cloud/google_service"
+require_relative "cloud/google_service_helpers"
+require_relative "cloud/google_service_options"
 
 class Chef
   class Knife

--- a/lib/chef/knife/google_zone_list.rb
+++ b/lib/chef/knife/google_zone_list.rb
@@ -19,9 +19,9 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require "chef/knife/cloud/google_service"
-require "chef/knife/cloud/google_service_helpers"
-require "chef/knife/cloud/google_service_options"
+require_relative "cloud/google_service"
+require_relative "cloud/google_service_helpers"
+require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
   class GoogleZoneList < ResourceListCommand


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>