### PR TITLE
 Lazy load the google SDK to prevent impacting knife performance

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -16,10 +16,10 @@ steps:
     executor:
       docker:
         image: ruby:2.6-buster
-- label: run-specs-ruby-2.7-rc
+- label: run-specs-ruby-2.7
   command:
     - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
-        image: ruby:2.7-rc-buster
+        image: ruby:2.7-buster

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,1 +1,0 @@
-daysUntilLock: 60

--- a/lib/chef/knife/google_disk_create.rb
+++ b/lib/chef/knife/google_disk_create.rb
@@ -19,8 +19,6 @@
 
 require "chef/knife"
 require "chef/knife/cloud/command"
-require_relative "cloud/google_service"
-require_relative "cloud/google_service_helpers"
 require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
@@ -29,6 +27,10 @@ class Chef::Knife::Cloud
     include GoogleServiceOptions
 
     banner "knife google disk create NAME --gce-disk-size N (options)"
+
+    deps do
+      require_relative "cloud/google_service"
+    end
 
     option :disk_size,
       long:        "--gce-disk-size SIZE",

--- a/lib/chef/knife/google_disk_delete.rb
+++ b/lib/chef/knife/google_disk_delete.rb
@@ -19,8 +19,6 @@
 
 require "chef/knife"
 require "chef/knife/cloud/command"
-require_relative "cloud/google_service"
-require_relative "cloud/google_service_helpers"
 require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
@@ -29,6 +27,10 @@ class Chef::Knife::Cloud
     include GoogleServiceOptions
 
     banner "knife google disk delete NAME [NAME] (options)"
+
+    deps do
+      require_relative "cloud/google_service"
+    end
 
     def validate_params!
       check_for_missing_config_values!(:gce_zone)

--- a/lib/chef/knife/google_disk_list.rb
+++ b/lib/chef/knife/google_disk_list.rb
@@ -19,8 +19,6 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require_relative "cloud/google_service"
-require_relative "cloud/google_service_helpers"
 require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
@@ -29,6 +27,10 @@ class Chef::Knife::Cloud
     include GoogleServiceOptions
 
     banner "knife google disk list"
+
+    deps do
+      require_relative "cloud/google_service"
+    end
 
     def validate_params!
       check_for_missing_config_values!(:gce_zone)

--- a/lib/chef/knife/google_image_list.rb
+++ b/lib/chef/knife/google_image_list.rb
@@ -27,7 +27,6 @@ class Chef::Knife::Cloud
 
     banner "knife google image list"
 
-
     deps do
       require_relative "cloud/google_service"
     end

--- a/lib/chef/knife/google_image_list.rb
+++ b/lib/chef/knife/google_image_list.rb
@@ -18,8 +18,6 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require_relative "cloud/google_service"
-require_relative "cloud/google_service_helpers"
 require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
@@ -28,6 +26,11 @@ class Chef::Knife::Cloud
     include GoogleServiceOptions
 
     banner "knife google image list"
+
+
+    deps do
+      require_relative "cloud/google_service"
+    end
 
     def validate_params!
       check_for_missing_config_values!

--- a/lib/chef/knife/google_project_quotas.rb
+++ b/lib/chef/knife/google_project_quotas.rb
@@ -19,8 +19,6 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require_relative "cloud/google_service"
-require_relative "cloud/google_service_helpers"
 require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
@@ -29,6 +27,11 @@ class Chef::Knife::Cloud
     include GoogleServiceOptions
 
     banner "knife google project quotas"
+
+
+    deps do
+      require_relative "cloud/google_service"
+    end
 
     def validate_params!
       check_for_missing_config_values!

--- a/lib/chef/knife/google_project_quotas.rb
+++ b/lib/chef/knife/google_project_quotas.rb
@@ -28,7 +28,6 @@ class Chef::Knife::Cloud
 
     banner "knife google project quotas"
 
-
     deps do
       require_relative "cloud/google_service"
     end

--- a/lib/chef/knife/google_region_list.rb
+++ b/lib/chef/knife/google_region_list.rb
@@ -19,8 +19,6 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require_relative "cloud/google_service"
-require_relative "cloud/google_service_helpers"
 require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
@@ -29,6 +27,11 @@ class Chef::Knife::Cloud
     include GoogleServiceOptions
 
     banner "knife google region list"
+
+
+    deps do
+      require_relative "cloud/google_service"
+    end
 
     def validate_params!
       check_for_missing_config_values!

--- a/lib/chef/knife/google_region_list.rb
+++ b/lib/chef/knife/google_region_list.rb
@@ -28,7 +28,6 @@ class Chef::Knife::Cloud
 
     banner "knife google region list"
 
-
     deps do
       require_relative "cloud/google_service"
     end

--- a/lib/chef/knife/google_region_quotas.rb
+++ b/lib/chef/knife/google_region_quotas.rb
@@ -28,7 +28,6 @@ class Chef::Knife::Cloud
 
     banner "knife google region quotas"
 
-
     deps do
       require_relative "cloud/google_service"
     end

--- a/lib/chef/knife/google_region_quotas.rb
+++ b/lib/chef/knife/google_region_quotas.rb
@@ -19,8 +19,6 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require_relative "cloud/google_service"
-require_relative "cloud/google_service_helpers"
 require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
@@ -29,6 +27,11 @@ class Chef::Knife::Cloud
     include GoogleServiceOptions
 
     banner "knife google region quotas"
+
+
+    deps do
+      require_relative "cloud/google_service"
+    end
 
     def validate_params!
       check_for_missing_config_values!

--- a/lib/chef/knife/google_server_create.rb
+++ b/lib/chef/knife/google_server_create.rb
@@ -30,7 +30,6 @@ class Chef::Knife::Cloud
 
     banner "knife google server create NAME -m MACHINE_TYPE -I IMAGE (options)"
 
-
     deps do
       require_relative "cloud/google_service"
     end

--- a/lib/chef/knife/google_server_create.rb
+++ b/lib/chef/knife/google_server_create.rb
@@ -20,8 +20,6 @@
 require "chef/knife"
 require "chef/knife/cloud/server/create_command"
 require "chef/knife/cloud/server/create_options"
-require_relative "cloud/google_service"
-require_relative "cloud/google_service_helpers"
 require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
@@ -31,6 +29,11 @@ class Chef::Knife::Cloud
     include ServerCreateOptions
 
     banner "knife google server create NAME -m MACHINE_TYPE -I IMAGE (options)"
+
+
+    deps do
+      require_relative "cloud/google_service"
+    end
 
     option :machine_type,
       short:       "-m MACHINE_TYPE",

--- a/lib/chef/knife/google_server_delete.rb
+++ b/lib/chef/knife/google_server_delete.rb
@@ -32,7 +32,6 @@ class Chef
 
         banner "knife google server delete INSTANCE_NAME [INSTANCE_NAME] (options)"
 
-
         deps do
           require_relative "cloud/google_service"
         end

--- a/lib/chef/knife/google_server_delete.rb
+++ b/lib/chef/knife/google_server_delete.rb
@@ -20,8 +20,6 @@
 require "chef/knife"
 require "chef/knife/cloud/server/delete_options"
 require "chef/knife/cloud/server/delete_command"
-require_relative "cloud/google_service"
-require_relative "cloud/google_service_helpers"
 require_relative "cloud/google_service_options"
 
 class Chef
@@ -33,6 +31,11 @@ class Chef
         include GoogleServiceOptions
 
         banner "knife google server delete INSTANCE_NAME [INSTANCE_NAME] (options)"
+
+
+        deps do
+          require_relative "cloud/google_service"
+        end
 
         def validate_params!
           check_for_missing_config_values!

--- a/lib/chef/knife/google_server_list.rb
+++ b/lib/chef/knife/google_server_list.rb
@@ -27,7 +27,6 @@ class Chef::Knife::Cloud
     include GoogleServiceHelpers
     include GoogleServiceOptions
 
-
     deps do
       require_relative "cloud/google_service"
     end

--- a/lib/chef/knife/google_server_list.rb
+++ b/lib/chef/knife/google_server_list.rb
@@ -20,14 +20,17 @@
 require "chef/knife"
 require "chef/knife/cloud/server/list_command"
 require "chef/knife/cloud/server/list_options"
-require_relative "cloud/google_service"
-require_relative "cloud/google_service_helpers"
 require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
   class GoogleServerList < ServerListCommand
     include GoogleServiceHelpers
     include GoogleServiceOptions
+
+
+    deps do
+      require_relative "cloud/google_service"
+    end
 
     banner "knife google server list"
 

--- a/lib/chef/knife/google_server_show.rb
+++ b/lib/chef/knife/google_server_show.rb
@@ -19,8 +19,6 @@
 require "chef/knife"
 require "chef/knife/cloud/server/show_options"
 require "chef/knife/cloud/server/show_command"
-require_relative "cloud/google_service"
-require_relative "cloud/google_service_helpers"
 require_relative "cloud/google_service_options"
 
 class Chef
@@ -32,6 +30,11 @@ class Chef
         include GoogleServiceOptions
 
         banner "knife google server show INSTANCE_NAME (options)"
+
+
+        deps do
+          require_relative "cloud/google_service"
+        end
 
         def validate_params!
           check_for_missing_config_values!(:gce_zone)

--- a/lib/chef/knife/google_server_show.rb
+++ b/lib/chef/knife/google_server_show.rb
@@ -31,7 +31,6 @@ class Chef
 
         banner "knife google server show INSTANCE_NAME (options)"
 
-
         deps do
           require_relative "cloud/google_service"
         end

--- a/lib/chef/knife/google_zone_list.rb
+++ b/lib/chef/knife/google_zone_list.rb
@@ -19,8 +19,6 @@
 
 require "chef/knife"
 require "chef/knife/cloud/list_resource_command"
-require_relative "cloud/google_service"
-require_relative "cloud/google_service_helpers"
 require_relative "cloud/google_service_options"
 
 class Chef::Knife::Cloud
@@ -29,6 +27,11 @@ class Chef::Knife::Cloud
     include GoogleServiceOptions
 
     banner "knife google zone list"
+
+
+    deps do
+      require_relative "cloud/google_service"
+    end
 
     def validate_params!
       check_for_missing_config_values!

--- a/lib/chef/knife/google_zone_list.rb
+++ b/lib/chef/knife/google_zone_list.rb
@@ -28,7 +28,6 @@ class Chef::Knife::Cloud
 
     banner "knife google zone list"
 
-
     deps do
       require_relative "cloud/google_service"
     end


### PR DESCRIPTION
If we require these files every time we load this plugin then we have to load the SDK just to get knife help. This reduces help load time from 2.99s to 1.43s

Signed-off-by: Tim Smith <tsmith@chef.io>