### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ rescue LoadError
 end
 
 begin
-  require "yard"
+  require "yard" unless defined?(YARD)
   YARD::Rake::YardocTask.new(:docs)
 rescue LoadError
   puts "yard is not available. bundle install first to make sure all dependencies are installed."

--- a/lib/chef/knife/cloud/google_service.rb
+++ b/lib/chef/knife/cloud/google_service.rb
@@ -22,7 +22,7 @@ require "chef/knife/cloud/service"
 require "chef/knife/cloud/helpers"
 require_relative "google_service_helpers"
 require "google/apis/compute_v1"
-require "ipaddr"
+require "ipaddr" unless defined?(IPAddr)
 require_relative "../../../knife-google/version"
 
 class Chef::Knife::Cloud


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>