### PR TITLE
Remove unused simplecov dev dep

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,5 +25,4 @@ group :development do
   gem "pry-byebug"
   gem "pry-stack_explorer"
   gem "rb-readline"
-  gem "simplecov", "~> 0.9"
 end


### PR DESCRIPTION
This causes install issues on Ruby 2.4.

Signed-off-by: Tim Smith <tsmith@chef.io>