### PR TITLE
CHEF-1920 Fixed the knife-google verify test failure

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -10,20 +10,13 @@ expeditor:
       timeout_in_minutes: 30
 
 steps:
-- label: run-lint-and-specs-ruby-2.7
+- label: run-lint-and-specs-ruby-3.1
   command:
     - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
-        image: ruby:2.7-buster
-- label: run-lint-and-specs-ruby-3.0
-  command:
-    - .expeditor/run_linux_tests.sh rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:3.0-buster
+        image: ruby:3.1-buster
 - label: run-specs-windows
   command:
     - bundle config set --local without docs debug
@@ -33,4 +26,4 @@ steps:
     executor:
       docker:
         host_os: windows
-        image: rubydistros/windows-2019:3.0
+        image: rubydistros/windows-2019:3.1

--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files         = %w{LICENSE} + Dir.glob("lib/**/*")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.1"
 
   s.add_dependency "knife"
   s.add_dependency "knife-cloud",       ">= 4.0.0"


### PR DESCRIPTION
### Description

updated ruby version to 3.1 and removed 2.7 and 3.0 ruby verify pipeline as the latest chef 18.2.7 supports ruby >= 3.1

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG