### PR TITLE
Update knife dependency to >= 18.0"

### DIFF
--- a/knife-google.gemspec
+++ b/knife-google.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 3.1"
 
-  s.add_dependency "knife"
-  s.add_dependency "knife-cloud",       ">= 4.0.0"
-  s.add_dependency "google-api-client", ">= 0.23.9", "< 0.53.0" # each version introduces breaking changes which we need to validate
+  s.add_dependency "knife", ">= 18.0"
+  # s.add_dependency "knife-cloud", ">= 4.0.0"
+  s.add_dependency "google-api-client", ">= 0.23.9", "<= 0.53.0" # each version introduces breaking changes which we need to validate
   s.add_dependency "gcewinpass",        "~> 1.1"
   s.add_dependency "syslog", "~> 0.3"
 end


### PR DESCRIPTION
### Description

Remove knife-cloud from gemspec and add GitHub dependency
- Update knife dependency to >= 18.0"
- Remove knife-cloud dependency from knife-google.gemspec until knife-cloud latest gem got released

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG