### PR TITLE
Add --winpass-timeout flag for gcewinpass password reset

### DIFF
--- a/lib/chef/knife/google_server_create.rb
+++ b/lib/chef/knife/google_server_create.rb
@@ -150,6 +150,12 @@ class Chef::Knife::Cloud
       long:        "--gce-email EMAIL_ADDRESS",
       description: "email address of the logged-in Google Cloud user; required for bootstrapping windows hosts"
 
+    option :winpass_timeout,
+      long:        "--winpass-timeout SECS",
+      description: "Timeout in seconds for the Windows password reset operation via gcewinpass. Defaults to 120.",
+      default:     120,
+      proc:        proc { |secs| secs.to_i }
+
     option :local_ssd,
       long:        "--gce-local-ssd",
       description: "Local SSDs are physically attached to the server that hosts your VM instance. Local SSDs have higher throughput and lower latency than standard persistent disks or SSD persistent disks.",
@@ -302,7 +308,8 @@ class Chef::Knife::Cloud
         instance_name: instance_name,
         email:         email,
         username:      config[:connection_user],
-        debug:         gcewinpass_debug_mode
+        debug:         gcewinpass_debug_mode,
+        timeout:       config[:winpass_timeout]
       ).new_password
     end
 

--- a/lib/chef/knife/google_server_create.rb
+++ b/lib/chef/knife/google_server_create.rb
@@ -302,15 +302,16 @@ class Chef::Knife::Cloud
     end
 
     def reset_windows_password
-      GoogleComputeWindowsPassword.new(
+      opts = {
         project:       project,
         zone:          zone,
         instance_name: instance_name,
         email:         email,
         username:      config[:connection_user],
         debug:         gcewinpass_debug_mode,
-        timeout:       config[:winpass_timeout]
-      ).new_password
+      }
+      opts[:timeout] = config[:winpass_timeout] unless config[:winpass_timeout].nil?
+      GoogleComputeWindowsPassword.new(**opts).new_password
     end
 
     def gcewinpass_debug_mode

--- a/spec/google_server_create_spec.rb
+++ b/spec/google_server_create_spec.rb
@@ -259,10 +259,10 @@ describe Chef::Knife::Cloud::GoogleServerCreate do
       command.reset_windows_password
     end
 
-    it "passes nil as timeout when winpass_timeout is not set in config" do
+    it "does not pass timeout when winpass_timeout is not set in config" do
       winpass = double("winpass", new_password: "my_password")
       expect(GoogleComputeWindowsPassword).to receive(:new).with(
-        hash_including(timeout: nil)
+        hash_not_including(:timeout)
       ).and_return(winpass)
       command.reset_windows_password
     end

--- a/spec/google_server_create_spec.rb
+++ b/spec/google_server_create_spec.rb
@@ -249,6 +249,35 @@ describe Chef::Knife::Cloud::GoogleServerCreate do
       expect(GoogleComputeWindowsPassword).to receive(:new).and_return(winpass)
       expect(command.reset_windows_password).to eq("my_password")
     end
+
+    it "passes the winpass_timeout config to gcewinpass" do
+      command.config[:winpass_timeout] = 300
+      winpass = double("winpass", new_password: "my_password")
+      expect(GoogleComputeWindowsPassword).to receive(:new).with(
+        hash_including(timeout: 300)
+      ).and_return(winpass)
+      command.reset_windows_password
+    end
+
+    it "passes nil as timeout when winpass_timeout is not set in config" do
+      winpass = double("winpass", new_password: "my_password")
+      expect(GoogleComputeWindowsPassword).to receive(:new).with(
+        hash_including(timeout: nil)
+      ).and_return(winpass)
+      command.reset_windows_password
+    end
+
+    it "uses the default winpass_timeout of 120 defined in the option" do
+      expect(described_class.options[:winpass_timeout][:default]).to eq(120)
+    end
+  end
+
+  describe "winpass_timeout option is passed on CLI" do
+    let(:google_server_create) { Chef::Knife::Cloud::GoogleServerCreate.new(["--winpass-timeout", "300"]) }
+
+    it "sets winpass_timeout to the provided value as an integer" do
+      expect(google_server_create.config[:winpass_timeout]).to eq(300)
+    end
   end
 
   describe "local_ssd option is passed on CLI" do


### PR DESCRIPTION
Expose the gcewinpass timeout option via a new CLI flag --winpass-timeout SECS so users can override the default 120-second timeout for Windows password reset operations.

- Add `--winpass-timeout` option (default: 120) to knife google server create
- Pass `timeout:` to GoogleComputeWindowsPassword.new in reset_windows_password
- Add RSpec tests covering custom timeout, nil passthrough, default value, and CLI flag parsing


### Description


### Issues Resolved



### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG